### PR TITLE
Remove dependsOn from Bicep types definitions

### DIFF
--- a/src/generator/src/Bicep.TypeGen.Autorest/Processors/ProviderTypeGenerator.cs
+++ b/src/generator/src/Bicep.TypeGen.Autorest/Processors/ProviderTypeGenerator.cs
@@ -62,7 +62,6 @@ namespace Azure.Bicep.TypeGen.Autorest.Processors
                 ["name"] = CreateObjectProperty(resourceName, ObjectPropertyFlags.Required | ObjectPropertyFlags.DeployTimeConstant),
                 ["type"] = CreateObjectProperty(type, ObjectPropertyFlags.ReadOnly | ObjectPropertyFlags.DeployTimeConstant),
                 ["apiVersion"] = CreateObjectProperty(apiVersionType, ObjectPropertyFlags.ReadOnly | ObjectPropertyFlags.DeployTimeConstant),
-                ["dependsOn"] = CreateObjectProperty(dependsOnType, ObjectPropertyFlags.WriteOnly),
             };
         }
 


### PR DESCRIPTION
DependsOn is already added by the Bicep code, and is no longer needed in the type definitions.