### PR TITLE
Fixed package descriptions

### DIFF
--- a/src/Bicep.Types.Az/Bicep.Types.Az.csproj
+++ b/src/Bicep.Types.Az/Bicep.Types.Az.csproj
@@ -5,6 +5,7 @@
     <EnableNuget>true</EnableNuget>
     <AssemblyName>Azure.Bicep.Types.Az</AssemblyName>
     <RootNamespace>Azure.Bicep.Types.Az</RootNamespace>
+    <Description>Bicep types generated from public Azure OpenAPI specs</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Bicep.Types/Bicep.Types.csproj
+++ b/src/Bicep.Types/Bicep.Types.csproj
@@ -5,6 +5,7 @@
     <EnableNuget>true</EnableNuget>
     <AssemblyName>Azure.Bicep.Types</AssemblyName>
     <RootNamespace>Azure.Bicep.Types</RootNamespace>
+    <Description>Shared contracts for Bicep types</Description>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
We had a placeholder descriptions for all of our packages:
![image](https://user-images.githubusercontent.com/22460039/113465920-7508ad80-93ec-11eb-9074-2c117882763b.png)

This is now fixed.