### PR TITLE
Only accept ObjectSchema for PUT body

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,16 +13,21 @@ See [/generated/index.md](./generated/index.md) for a searchable list of all the
 1. Merge the PR. Type differences can be reviewed by looking at the Markdown files in [/generated](./generated).
 
 ## Running generation locally
+### Initial setup
 1. Ensure you have a copy of the [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs) repo checked out locally.
-1. Build the dotnet generator code:
+1. Build the autorest extension code:
     ```sh
-    dotnet build
+    cd src/autorest.bicep
+    npm ci
+    npm run build
     ```
 1. Change to the generator directory, and install dependencies:
     ```sh
-    cd src/generator
-    npm i
+    cd ../../src/generator
+    npm ci
     ```
+
+### Running
 1. To run generation across the entire specs repo:
     ```sh
     npm run generate -- --specs-dir {path to azure-rest-api-specs}
@@ -35,6 +40,15 @@ See [/generated/index.md](./generated/index.md) for a searchable list of all the
     ```sh
     npm run generate -- --help
     ```
+
+### Debugging in VSCode
+1. Ensure you have cloned the [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs) repo into the same directory that you have cloned this repo - e.g. so you have the following folder structure:
+    ```
+    .
+    ./bicep-types-az
+    ./azure-rest-api-specs
+    ```
+1. Use the `Generate Single` VSCode action, and specify a 'base path' from the `specifications` folder in the [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs) repo - e.g. `compute` or `automation`. You should now be able to step through the `src/generator` and `src/autorest.bicep` extension code with the VSCode debugger.
 
 ## Contributing
 

--- a/src/autorest.bicep/src/resources.ts
+++ b/src/autorest.bicep/src/resources.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { ChoiceSchema, CodeModel, HttpMethod, HttpParameter, HttpRequest, HttpResponse, ImplementationLocation, ObjectSchema, Operation, Parameter, ParameterLocation, Request, Response, Schema, SchemaResponse, SealedChoiceSchema, Metadata } from "@autorest/codemodel";
+import { ChoiceSchema, CodeModel, HttpMethod, HttpParameter, HttpRequest, HttpResponse, ImplementationLocation, ObjectSchema, Operation, Parameter, ParameterLocation, Request, Response, Schema, SchemaResponse, SealedChoiceSchema, Metadata, HttpWithBodyRequest, SerializationStyle } from "@autorest/codemodel";
 import { Channel, Host } from "@autorest/extension-base";
 import { keys, Dictionary, values } from 'lodash';
 import { success, failure, Result } from './utils';
@@ -165,6 +165,7 @@ export function getProviderDefinitions(codeModel: CodeModel, host: Host): Provid
       const putData = getPutSchema(putOperation);
       const getData = getGetSchema(getOperation) ?? putData;
       if (!putData) {
+        logWarning(`Skipping path '${lcPath}': Failed to find JSON PUT schema`);
         continue;
       }
 
@@ -220,11 +221,10 @@ export function getProviderDefinitions(codeModel: CodeModel, host: Host): Provid
     }
 
     for (const response of validResponses) {
-      const schemaResponse = response as SchemaResponse;
-      if (schemaResponse) {
+      if (response.protocol.http instanceof HttpResponse && response instanceof SchemaResponse && response.schema instanceof ObjectSchema) {
         return {
-          response: (response.protocol.http as HttpResponse),
-          schema: schemaResponse.schema as ObjectSchema,
+          response: response.protocol.http,
+          schema: response.schema,
         };
       }
     }
@@ -248,20 +248,18 @@ export function getProviderDefinitions(codeModel: CodeModel, host: Host): Provid
 
     for (const request of validRequests) {
       const parameters = combineParameters(operation, request);
-      const bodyParameters = parameters.filter(p => (p.protocol.http as HttpParameter)?.in === ParameterLocation.Body);
-      if (bodyParameters.length > 0) {
+      const bodyParameter = parameters.filter(p => (p.protocol.http as HttpParameter)?.in === ParameterLocation.Body)[0];
+
+      if (request.protocol.http instanceof HttpRequest && bodyParameter instanceof Parameter && bodyParameter.schema instanceof ObjectSchema) {
         return {
-          request: (request.protocol.http as HttpRequest),
+          request: request.protocol.http,
           parameters,
-          schema: bodyParameters[0].schema as ObjectSchema,
+          schema: bodyParameter.schema,
         };
       }
     }
 
-    return {
-      request: (validRequests[0].protocol.http as HttpRequest),
-      parameters: combineParameters(operation, validRequests[0]),
-    };
+    return;
   }
 
   function parseMethod(path: string, parameters: Parameter[], apiVersion: string): Result<ResourceDescriptor[], string> {

--- a/src/autorest.bicep/src/resources.ts
+++ b/src/autorest.bicep/src/resources.ts
@@ -165,7 +165,6 @@ export function getProviderDefinitions(codeModel: CodeModel, host: Host): Provid
       const putData = getPutSchema(putOperation);
       const getData = getGetSchema(getOperation) ?? putData;
       if (!putData) {
-        logWarning(`Skipping path '${lcPath}': Failed to find JSON PUT schema`);
         continue;
       }
 
@@ -259,7 +258,10 @@ export function getProviderDefinitions(codeModel: CodeModel, host: Host): Provid
       }
     }
 
-    return;
+    return {
+      request: (validRequests[0].protocol.http as HttpRequest),
+      parameters: combineParameters(operation, validRequests[0]),
+    };
   }
 
   function parseMethod(path: string, parameters: Parameter[], apiVersion: string): Result<ResourceDescriptor[], string> {


### PR DESCRIPTION
This addresses https://github.com/Azure/bicep/issues/784#issuecomment-886864414 - the swagger exposes a JSON PUT operation as well as a binary operation. Here we ensure we always pick the JSON one.

Closes https://github.com/Azure/bicep/issues/3754