### PR TITLE
Add FabricBot config to support auto-merge type generation PRs created by CI

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -1,0 +1,78 @@
+[
+  {
+    "taskType": "trigger",
+    "capabilityId": "AutoMerge",
+    "subCapability": "AutoMerge",
+    "version": "1.0",
+    "config": {
+      "label": "AutoMerge",
+      "minMinutesOpen": "5",
+      "taskName": "Automatically merge PRs with AutoMerge label",
+      "mergeType": "squash",
+      "deleteBranches": true,
+      "enforceDMPAsStatus": true,
+      "removeLabelOnPush": true,
+      "usePrDescriptionAsCommitMessage": true
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isAction",
+            "parameters": {
+              "action": "opened"
+            }
+          },
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": "github-actions[bot]"
+            }
+          },
+          {
+            "name": "titleContains",
+            "parameters": {
+              "titlePattern": "Update Generated Types"
+            }
+          }
+        ]
+      },
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request",
+        "issues",
+        "project_card"
+      ],
+      "taskName": "Automatically approve type generation PRs sent by github-actions[bot]",
+      "actions": [
+        {
+          "name": "closeIssue",
+          "parameters": {}
+        },
+        {
+          "name": "reopenIssue",
+          "parameters": {}
+        },
+        {
+          "name": "addLabel",
+          "parameters": {
+            "label": "AutoMerge"
+          }
+        },
+        {
+          "name": "approvePullRequest",
+          "parameters": {
+            "comment": "Automatically approving type generation pull request sent by @github-actions[bot]."
+          }
+        }
+      ]
+    }
+  }
+]


### PR DESCRIPTION
The config was created via the FabricBot UI: https://portal.fabricbot.ms.