### PR TITLE
Don't invoke polymorphic type handler when PUT not polymorphic

### DIFF
--- a/src/autorest.bicep/src/type-generator.ts
+++ b/src/autorest.bicep/src/type-generator.ts
@@ -60,7 +60,7 @@ export function generateTypes(host: AutorestExtensionHost, definition: ProviderD
       }
     }
 
-    if (putSchema?.discriminator || getSchema?.discriminator) {
+    if (putSchema?.discriminator) {
       const discriminatedObjectType = factory.lookupType(resourceDefinition) as DiscriminatedObjectType;
 
       handlePolymorphicType(discriminatedObjectType, putSchema, getSchema);


### PR DESCRIPTION
This PR will prevent issues like #802 from blocking type generation for a service in the future. While it is probably not correct that `Microsoft.SecurityInsights/threatIntelligence/indicators` resources are polymorphic on read but not on write, the issue that manifested in the type generator stemmed from the fact that [we look at the `PUT` request schema when defining a resource's body type](https://github.com/Azure/bicep-types-az/blob/main/src/autorest.bicep/src/type-generator.ts#L44), then invoke `handlePolymorphicType` if either the `PUT` request *or* the `GET` response is defined as a discriminated object.

Running the type generator with this change did not alter the types emitted for any namespace *other* than `Microsoft.SecurityInsights`. Changes for `Microsoft.SecurityInsights` were:

* Picking up the API versions that have been released since types stopped being generated for `securityinsights` 6 months ago (**2021-10-01**, **2021-10-01-preview**, **2022-01-01-preview**, and **2022-04-01-preview**), and
* Open enums getting a `| string` branch (as expected from #828).