### PR TITLE
Sort object types before writing markdown file

### DIFF
--- a/src/autorest.bicep/src/writers/markdown.ts
+++ b/src/autorest.bicep/src/writers/markdown.ts
@@ -186,7 +186,7 @@ export function writeMarkdown(provider: string, apiVersion: string, types: TypeB
 
     const resourceTypes = orderBy(types.filter(t => t instanceof ResourceType) as ResourceType[], x => x.Name.split('@')[0].toLowerCase());
     const resourceFunctionTypes = orderBy(types.filter(t => t instanceof ResourceFunctionType) as ResourceFunctionType[], x => x.Name.split('@')[0].toLowerCase());
-    const typesToWrite: TypeBase[] = [...resourceTypes, ...resourceFunctionTypes];
+    const typesToWrite: TypeBase[] = []
 
     for (const resourceType of resourceTypes) {
       findTypesToWrite(types, typesToWrite, resourceType.Body);
@@ -202,7 +202,19 @@ export function writeMarkdown(provider: string, apiVersion: string, types: TypeB
       findTypesToWrite(types, typesToWrite, resourceFunctionType.Output);
     }
 
-    for (const type of typesToWrite) {
+    typesToWrite.sort((a, b) => {
+      const aName = (a as ObjectType).Name?.toLowerCase();
+      const bName = (b as ObjectType).Name?.toLowerCase();
+
+      if (aName === undefined) {
+        return bName === undefined ? 0 : 1;
+      }
+      if (bName === undefined || aName < bName) return -1;
+      if (bName > aName) return 1;
+      return 0;
+    });
+
+    for (const type of (resourceTypes as TypeBase[]).concat(resourceFunctionTypes).concat(typesToWrite)) {
       writeComplexType(types, type, 2, true);
     }
 

--- a/src/autorest.bicep/test/integration/generated/basic/test.rp1/2021-10-31/types.md
+++ b/src/autorest.bicep/test/integration/generated/basic/test.rp1/2021-10-31/types.md
@@ -23,11 +23,17 @@
 * **Input**: [FoosRequest](#foosrequest)
 * **Output**: [FoosResponse](#foosresponse)
 
-## TestType1Properties
+## FoosRequest
 ### Properties
-* **basicString**: string: Description for a basic string property.
-* **skuTier**: 'Basic' | 'Free' | 'Premium' | 'Standard': This field is required to be implemented by the Resource Provider if the service has more than one tier, but is not required on a PUT.
-* **stringEnum**: 'Bar' | 'Foo' | string: Description for a basic enum property.
+* **someString**: string (Required, WriteOnly): The foo request string
+
+## FoosResponse
+### Properties
+* **someString**: string (ReadOnly): The foo response string
+
+## FoosResponse
+### Properties
+* **someString**: string (ReadOnly): The foo response string
 
 ## SystemData
 ### Properties
@@ -38,20 +44,14 @@
 * **lastModifiedBy**: string: The identity that last modified the resource.
 * **lastModifiedByType**: 'Application' | 'Key' | 'ManagedIdentity' | 'User' | string: The type of identity that created the resource.
 
+## TestType1Properties
+### Properties
+* **basicString**: string: Description for a basic string property.
+* **skuTier**: 'Basic' | 'Free' | 'Premium' | 'Standard': This field is required to be implemented by the Resource Provider if the service has more than one tier, but is not required on a PUT.
+* **stringEnum**: 'Bar' | 'Foo' | string: Description for a basic enum property.
+
 ## TrackedResourceTags
 ### Properties
 ### Additional Properties
 * **Additional Properties Type**: string
-
-## FoosResponse
-### Properties
-* **someString**: string (ReadOnly): The foo response string
-
-## FoosRequest
-### Properties
-* **someString**: string (Required, WriteOnly): The foo request string
-
-## FoosResponse
-### Properties
-* **someString**: string (ReadOnly): The foo response string
 


### PR DESCRIPTION
This PR sorts the object types written to generated markdown files alphabetically by name. It's an attempt to make PRs that alter what qualifies as a resource (e.g., #805) easier to review. 

Currently, the order in which types appear in generated markdown files is determined by when they are used in a provider's swagger model. As a consequence, when a PR expands the definition of what qualifies as a resource, that can cause shapes to change position in the `.md` file, leading to a bunch of noise in the resulting diff, e.g.:

![image](https://user-images.githubusercontent.com/705500/172636516-83a7f09b-ee47-4b64-bae0-a7d7e2170169.png)

With a stable sort, the diff for `.md` files would just be insertions.