### PR TITLE
Allow multiple intervening folders between provider name and API version

### DIFF
--- a/src/generator/src/cmd/generate.ts
+++ b/src/generator/src/cmd/generate.ts
@@ -114,7 +114,7 @@ async function generateAutorestConfig(logger: ILogger, readmePath: string, bicep
   // We expect a path format convention of <provider>/(preview|stable)/<yyyy>-<mm>-<dd>(|-preview)/<filename>.json
   // This information is used to generate individual tags in the generated autorest configuration
   // eslint-disable-next-line no-useless-escape
-  const pathRegex = /^(\$\(this-folder\)\/|)([^\/]+)\/[^\/]+\/(\d{4}-\d{2}-\d{2}(|-preview))\/.*\.json$/i;
+  const pathRegex = /^(\$\(this-folder\)\/|)([^\/]+)(?:\/[^\/]+)+\/(\d{4}-\d{2}-\d{2}(|-preview))\/.*\.json$/i;
 
   const readmeContents = await readFile(readmePath, { encoding: 'utf8' });
   const readmeMarkdown = markdown.parse(readmeContents);

--- a/src/generator/src/cmd/generate.ts
+++ b/src/generator/src/cmd/generate.ts
@@ -111,7 +111,7 @@ function normalizeJsonPath(jsonPath: string) {
 }
 
 async function generateAutorestConfig(logger: ILogger, readmePath: string, bicepReadmePath: string, config: GeneratorConfig) {
-  // We expect a path format convention of <provider>/(preview|stable)/<yyyy>-<mm>-<dd>(|-preview)/<filename>.json
+  // We expect a path format convention of <provider>/(any/number/of/intervening/folders)/<yyyy>-<mm>-<dd>(|-preview)/<filename>.json
   // This information is used to generate individual tags in the generated autorest configuration
   // eslint-disable-next-line no-useless-escape
   const pathRegex = /^(\$\(this-folder\)\/|)([^\/]+)(?:\/[^\/]+)+\/(\d{4}-\d{2}-\d{2}(|-preview))\/.*\.json$/i;


### PR DESCRIPTION
https://github.com/Azure/azure-rest-api-specs/pull/20103 introduced a change in the folder structure for Swagger specs for the Microsoft.Compute RP, leading to the deletion of all types for Microsoft.Compute in #1078. This PR updates the regex we use to parse swagger spec paths to accept multiple folders between the name of the provider and the API version.

Type gen result viewable at https://github.com/Azure/bicep-types-az/pull/1082