### PR TITLE
Deserialize manifest resources from stream

### DIFF
--- a/src/Bicep.Types.Az.UnitTests/packages.lock.json
+++ b/src/Bicep.Types.Az.UnitTests/packages.lock.json
@@ -57,8 +57,8 @@
       },
       "Azure.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.3.1",
-        "contentHash": "P/HUHAxPEQFP9hUohoPuy48eUyowL0dzNXFtKKIE+/EqQKObMATcQ7RjAcQrXaOIsYZ/Vk4gVreweJ3rkbYYJw==",
+        "resolved": "0.3.4",
+        "contentHash": "B+jpNssdLB6qDLmw0WhgsgziEnQZ1TB1tpDrJ69802jQdY3v0YRH0edE3/9QLtXBDHezD/Pbrh66deailLEN5Q==",
         "dependencies": {
           "System.Text.Json": "6.0.6"
         }
@@ -149,7 +149,7 @@
       "Azure.Bicep.Types.Az": {
         "type": "Project",
         "dependencies": {
-          "Azure.Bicep.Types": "[0.3.1, )"
+          "Azure.Bicep.Types": "[0.3.4, )"
         }
       }
     }

--- a/src/Bicep.Types.Az/Bicep.Types.Az.csproj
+++ b/src/Bicep.Types.Az/Bicep.Types.Az.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Bicep.Types" Version="0.3.1" />
+    <PackageReference Include="Azure.Bicep.Types" Version="0.3.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Bicep.Types.Az/Index/TypeIndexer.cs
+++ b/src/Bicep.Types.Az/Index/TypeIndexer.cs
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+using System.IO;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Threading.Tasks;
 
 namespace Azure.Bicep.Types.Az.Index
 {
@@ -15,6 +17,11 @@ namespace Azure.Bicep.Types.Az.Index
         public static TypeIndex DeserializeIndex(string content)
         {
             return JsonSerializer.Deserialize<TypeIndex>(content, SerializeOptions) ?? throw new JsonException("Failed to deserialize index");
+        }
+
+        public static TypeIndex DeserializeIndex(Stream contentStream)
+        {
+            return JsonSerializer.Deserialize<TypeIndex>(contentStream, SerializeOptions) ?? throw new JsonException("Failed to deserialize index");
         }
     }
 }

--- a/src/Bicep.Types.Az/packages.lock.json
+++ b/src/Bicep.Types.Az/packages.lock.json
@@ -4,9 +4,9 @@
     ".NETStandard,Version=v2.0": {
       "Azure.Bicep.Types": {
         "type": "Direct",
-        "requested": "[0.3.1, )",
-        "resolved": "0.3.1",
-        "contentHash": "P/HUHAxPEQFP9hUohoPuy48eUyowL0dzNXFtKKIE+/EqQKObMATcQ7RjAcQrXaOIsYZ/Vk4gVreweJ3rkbYYJw==",
+        "requested": "[0.3.4, )",
+        "resolved": "0.3.4",
+        "contentHash": "B+jpNssdLB6qDLmw0WhgsgziEnQZ1TB1tpDrJ69802jQdY3v0YRH0edE3/9QLtXBDHezD/Pbrh66deailLEN5Q==",
         "dependencies": {
           "System.Text.Json": "6.0.6"
         }


### PR DESCRIPTION
Currently to deserialize a manifest resource we are deflating the resource stream via a StreamReader to a string and then deserializing that string. Instead we can directly deserialize from the deflate stream without a string allocation. This upgrades to 0.3.4 of Azure.Bicep.Types so TypeSerializer can be called with a stream via Azure/bicep-types#7