### PR TITLE
Ignore operations with required headers or querystring parameters

### DIFF
--- a/src/autorest.bicep/src/resources.ts
+++ b/src/autorest.bicep/src/resources.ts
@@ -230,6 +230,11 @@ export function getProviderDefinitions(codeModel: CodeModel, host: AutorestExten
     }
 
     operations.forEach(operation => {
+      if ((operation.parameters?.filter(p => p.required && p.protocol.http?.in === "query" && p.language.default.name.toLowerCase() !== "apiversion")?.length ?? 0) > 0) {
+        logWarning(`Skipping ${operation.operationId} due to required querystring parameter`);
+        return;
+      }
+
       const requests = getHttpRequests(operation.requests);
       const getRequest = requests.filter(r => r.method === HttpMethod.Get)[0];
       if (getRequest) {

--- a/src/autorest.bicep/test/integration/specs/basic/resource-manager/Test.Rp1/stable/2021-10-31/spec.json
+++ b/src/autorest.bicep/test/integration/specs/basic/resource-manager/Test.Rp1/stable/2021-10-31/spec.json
@@ -783,5 +783,62 @@
         ]
       }
     }
+  },
+  "x-ms-paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Test.Rp1/testType1/{typeName}?export=true": {
+      "get": {
+        "summary": "Get a testType1 resource",
+        "description": "Get a testType1 resource",
+        "operationId": "TestType1_Export",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "prop": {"type": "string"}
+              }
+            }
+          },
+          "default": {
+            "description": "Detailed error information.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "export",
+            "in": "query",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "true"
+            ],
+            "x-ms-enum": {
+              "name": "ExportApi"
+            },
+            "description": "A description is required to be a `signatureParameter`"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "typeName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The testType1 resource name."
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          }
+        ]
+      }
+    }
   }
 }


### PR DESCRIPTION
Resolves https://github.com/Azure/bicep/issues/8511

ARM cannot call these operations, so a `reference` or resource declaration would fail at runtime. The `api-version` parameter is allowlisted, as ARM automatically injects this parameter into resource PUTs and reference GETs.

After running the type generator in #1173, I saw the following changes to the generated types:
* The `Microsoft.ApiManagement/service/apis` resource (across all API versions) no longer used the Swagger definition for the `ApiExport_Get` operation as its GET operation.
    * `ApiExport_Get` differed from standard GET lifecycle operation only in that it had a required `export=true` querystring parameter (i.e., the method and path were the same). ([Example from the 2021-08-01 API version](https://github.com/Azure/azure-rest-api-specs/blob/120cd067102146937c796ad856cb9993d051534f/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2021-08-01/apimapis.json#L4412))
* `microsoft.insights/workbooks@2018-06-17-preview` was made read-only.
    * The path's PUT operation requires [a `sourceId` querystring parameter](https://github.com/Azure/azure-rest-api-specs/blob/120cd067102146937c796ad856cb9993d051534f/specification/applicationinsights/resource-manager/Microsoft.Insights/preview/2018-06-17-preview/workbooks_API.json#L177).
* `Microsoft.Billing/billingAccounts/billingProfiles/transactions@2019-10-01-preview (ReadOnly)` was removed
    * This resource requires [a `periodStartDate` and a `periodEndDate` querystring parameters](https://github.com/Azure/azure-rest-api-specs/blob/120cd067102146937c796ad856cb9993d051534f/specification/billing/resource-manager/Microsoft.Billing/preview/2019-10-01-preview/billing.json#L3091-L3104).
* `Microsoft.DevHub/locations/githuboauth@2022-04-01-preview (ReadOnly)` was removed
    * Requires Github authentication data to be passed via [the `GitHubOAuthCodeParameter` and and `GitHubOAuthStateParameter` querystring parameters](https://github.com/Azure/azure-rest-api-specs/blob/120cd067102146937c796ad856cb9993d051534f/specification/developerhub/resource-manager/Microsoft.DevHub/preview/2022-04-01-preview/workflow.json#L136-L141).
* `Microsoft.MarketplaceNotifications/reviewsNotification@2021-03-03` was removed
    * Requires the user's principal ID to be passed in via [the `PrincipalId` querystring parameter](https://github.com/Azure/azure-rest-api-specs/blob/120cd067102146937c796ad856cb9993d051534f/specification/marketplacenotifications/resource-manager/Microsoft.MarketplaceNotifications/stable/2021-03-03/MarketplaceNotifications.json#L74).
* `Microsoft.Security/sqlVulnerabilityAssessments/baselineRules@2020-07-01-preview`, `Microsoft.Security/sqlVulnerabilityAssessments/scans@2020-07-01-preview (ReadOnly)`, and `Microsoft.Security/sqlVulnerabilityAssessments/scans/scanResults@2020-07-01-preview (ReadOnly)` were removed.
    * All require [a `workspaceId` querystring parameter](https://github.com/Azure/azure-rest-api-specs/blob/120cd067102146937c796ad856cb9993d051534f/specification/security/resource-manager/Microsoft.Security/preview/2020-07-01-preview/sqlVulnerabilityAssessmentsBaselineRuleOperations.json#L33).
* `Microsoft.Sql/servers/databases/maintenanceWindows` (all API versions) and `Microsoft.Synapse/workspaces/sqlPools/maintenancewindows` (all API versions) was removed
    * Require a `maintenanceWindowName` querystring parameter (e.g., [from `Microsoft.Sql/servers/databases/maintenanceWindows@2021-11-01`](https://github.com/Azure/azure-rest-api-specs/blob/120cd067102146937c796ad856cb9993d051534f/specification/sql/resource-manager/Microsoft.Sql/stable/2021-11-01/MaintenanceWindows.json#L41)).
* `Microsoft.Sql/servers/databases/maintenanceWindowOptions (ReadOnly)` (all API versions) and `Microsoft.Synapse/workspaces/sqlPools/maintenanceWindowOptions (ReadOnly)` (all API versions) was removed
    * Require a `maintenanceWindowOptionsName` querystring parameter (e.g., [from `Microsoft.Sql/servers/databases/maintenanceWindowsOptions@2021-11-01`](https://github.com/Azure/azure-rest-api-specs/blob/120cd067102146937c796ad856cb9993d051534f/specification/sql/resource-manager/Microsoft.Sql/stable/2021-11-01/MaintenanceWindowOptions.json#L41)).
* `Microsoft.Sql/servers/sqlVulnerabilityAssessments/baselines` (2022-02-01-preview & 2022-05-01-preview), `Microsoft.Sql/servers/sqlVulnerabilityAssessments/baselines/rules` (2022-02-01-preview & 2022-05-01-preview), `Microsoft.Sql/servers/sqlVulnerabilityAssessments/scans (ReadOnly)` (2022-02-01-preview & 2022-05-01-preview), and `Microsoft.Sql/servers/sqlVulnerabilityAssessments/scans/scanResults (ReadOnly)` (2022-02-01-preview & 2022-05-01-preview) are removed
    * All require a `systemDatabaseName` querystring parameter.
* `Microsoft.VMwareCloudSimple/dedicatedCloudNodes@2019-04-01` and `Microsoft.VMwareCloudSimple/virtualMachines@2019-04-01` were made read-only
    *  Both resources' PUT operations require a `referer` header