### PR TITLE
Correct cron expression and insert missing colon

### DIFF
--- a/.github/workflows/update-types.yml
+++ b/.github/workflows/update-types.yml
@@ -2,7 +2,7 @@ name: Update Types
 
 on:
   schedule:
-    - cron '5 45 * * SUN'
+    - cron: '45 5 * * SUN'
   workflow_dispatch:
     inputs:
       api_specs_ref:


### PR DESCRIPTION
I noticed the update-types workflow did not run this past Sunday as scheduled and found that the trigger was misconfigured.