### PR TITLE
Update path regex to allow paths with no provider identifier

### DIFF
--- a/src/generator/src/cmd/generate.ts
+++ b/src/generator/src/cmd/generate.ts
@@ -113,7 +113,7 @@ async function generateAutorestConfig(logger: ILogger, readmePath: string, bicep
   // We expect a path format convention of <provider>/(any/number/of/intervening/folders)/<yyyy>-<mm>-<dd>(|-preview)/<filename>.json
   // This information is used to generate individual tags in the generated autorest configuration
   // eslint-disable-next-line no-useless-escape
-  const pathRegex = /^(\$\(this-folder\)\/|)([^\/]+)(?:\/[^\/]+)+\/(\d{4}-\d{2}-\d{2}(|-preview))\/.*\.json$/i;
+  const pathRegex = /^(\$\(this-folder\)\/|)([^\/]+)(?:\/[^\/]+)*\/(\d{4}-\d{2}-\d{2}(|-preview))\/.*\.json$/i;
 
   const readmeContents = await readFile(readmePath, { encoding: 'utf8' });
   const readmeMarkdown = markdown.parse(readmeContents);


### PR DESCRIPTION
Resolves #1434 

`Microsoft.ContainerService` recently changed their folder structure so that the `readme.md` file is split between [`containerservice/resource-manager/Microsoft.ContainerService/aks/readme.md`](https://github.com/Azure/azure-rest-api-specs/blob/main/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/readme.md) (for AKS resources) and [`containerservice/resource-manager/Microsoft.ContainerService/fleet/readme.md`](https://github.com/Azure/azure-rest-api-specs/blob/main/specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/readme.md) (for ContainerFleetService resources). This unfortunately breaks the `pathRegex` in the type generator, which assumes that the `readme.md` file will be in the `<service-name>/resource-manager` file.

Updating the path regex to accept paths with only one directory preceding the API version appears to fix this, although it does cause the subsequent code within the generator to misidentify the provider name of the identified files. This doesn't seem to have any impact on code generation, though.

Sample type gen run viewable in #1432 