### PR TITLE
Allow multiple readmes in namespace

### DIFF
--- a/src/generator/src/cmd/generate.ts
+++ b/src/generator/src/cmd/generate.ts
@@ -50,6 +50,7 @@ executeSynchronous(async () => {
   // this file is deliberately gitignored as it'll be overwritten when using --single-path
   // it's used to generate the git commit message
   await mkdir(outputBaseDir, { recursive: true });
+  const subdirsCreated = new Set<string>();
   const summaryLogger = await getLogger(`${outputBaseDir}/summary.log`);
 
   // use consistent sorting to make log changes easier to review
@@ -74,9 +75,12 @@ executeSynchronous(async () => {
       await generateAutorestConfig(logger, readmePath, bicepReadmePath, config);
       await generateSchema(logger, readmePath, tmpOutputDir, logLevel, waitForDebugger);
 
-      // remove all previously-generated files and copy over results
-      await rm(outputDir, { recursive: true, force: true, });
-      await mkdir(outputDir, { recursive: true });
+      if (!subdirsCreated.has(outputDir)) {
+        subdirsCreated.add(outputDir);
+        // remove all previously-generated files and copy over results
+        await rm(outputDir, { recursive: true, force: true, });
+        await mkdir(outputDir, { recursive: true });
+      }
       await copyRecursive(tmpOutputDir, outputDir);
     } catch (err) {
       logErr(logger, err);


### PR DESCRIPTION
In the last couple automated type runs, a large number of API versions of `Microsoft.ContainerService` have been removed. This has been happening because [the `containerservice` Swagger spec namespace](https://github.com/Azure/azure-rest-api-specs/tree/main/specification/containerservice/resource-manager/Microsoft.ContainerService) has two sets of API versions -- one for `aks` and another for `fleet` -- each of which has its own `readme.md` file to control Autorest behavior for SDK generation. The generator script iterates through all `readme.md` files in the Swagger spec repo and generates Bicep types for each, but only after clearing out the types generated on previous runs. New and old types are matched by namespace, and both `specification/containerservice/resource-manager/Microsoft.ContainerService/aks/readme.md` and `specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/readme.md` have a namespace of `containerservice`.

This was not an issue before a couple of weeks ago because something about the `containerservice/fleet` readme was causing  an error to be thrown before we got to the part of the generator script where types generated in the last run are deleted. The service team fixed that issue, which led to all API versions in `containerservice/aks` being deleted following the successful run of `containerservice/fleet`.

The fix I went with in this PR is to clear out each generated type namespace at most once per run. This is imperfect, since it only works because there is no API version identifier shared between the specs in `containerservice/aks` with those in `containerservice/fleet`, but that should cause type generation to fail, so we be able to address it when/if it comes up.

Sample type generation run for this PR: #1615 