### PR TITLE
TASK 25736691: Publish package should use same version as nuget package

### DIFF
--- a/.github/workflows/publish-types.yml
+++ b/.github/workflows/publish-types.yml
@@ -49,9 +49,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         # use the nightly build of the Bicep CLI to publish the resource types provider
         run: bash <(curl -Ls https://aka.ms/bicep/nightly-cli.sh)
-      
-      - name: test install
-        run: ~/.azure/bin/bicep --version
         
       - name: Publish Azure Resource Types
         id: publish-types

--- a/.github/workflows/publish-types.yml
+++ b/.github/workflows/publish-types.yml
@@ -31,13 +31,17 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       
+      - name: Install nbgv
+        id: nbgv
+        uses: dotnet/nbgv@master
+
       - name: Generate tag for the package based on event type
         id: generate_tag
         run: |
           if [ "${{ github.event_name }}" == "push" ]; then
-            echo "tag=0.0.0-alpha-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+            echo "tag=${{ steps.nbgv.outputs.SimpleVersion }}" >> $GITHUB_OUTPUT
           else
-            echo "tag=0.0.0-alpha-pr${{ github.event.number }}" >> $GITHUB_OUTPUT
+            echo "tag=${{ steps.nbgv.outputs.SimpleVersion }}-pr${{ github.event.number }}" >> $GITHUB_OUTPUT
           fi
   
       - name: Intall Bicep CLI


### PR DESCRIPTION
Uses the nbgv value as the version so it matches the nuget package version in the statically compiled provider for Bicep