### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/update-types.yml
+++ b/.github/workflows/update-types.yml
@@ -71,14 +71,14 @@ jobs:
           summary="${summary//$'\n'/'%0A'}"
           summary="${summary//$'\r'/'%0D'}"
 
-          echo "::set-output name=summary::$summary"
+          echo "summary=$summary" >> $GITHUB_OUTPUT
         working-directory: src/generator
 
       - id: get_swagger_gh_uri
         name: Get GitHub URI for azure-rest-api-specs
         run: |
           git_sha=`git rev-parse --short HEAD`
-          echo "::set-output name=gh_uri::https://github.com/Azure/azure-rest-api-specs/tree/$git_sha"
+          echo "gh_uri=https://github.com/Azure/azure-rest-api-specs/tree/$git_sha" >> $GITHUB_OUTPUT
         working-directory: workflow-temp/azure-rest-api-specs
 
       - name: Commit and push


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter`