### PR TITLE
Fix issue generating polymorphic schemas

### DIFF
--- a/src/autorest.bicep/test/integration/generated/arm-schema/basic/test.rp1/2021-10-31/schema.json
+++ b/src/autorest.bicep/test/integration/generated/arm-schema/basic/test.rp1/2021-10-31/schema.json
@@ -13,17 +13,19 @@
           ],
           "type": "string"
         },
-        "bar": {
-          "description": "The bar property",
-          "type": "string"
-        },
-        "foo": {
-          "description": "The foo property",
-          "type": "string"
-        },
         "name": {
           "description": "The discriminatedUnionTestType resource name.",
           "type": "string"
+        },
+        "properties": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/DiscriminatedUnionTestTypeProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
         },
         "type": {
           "enum": [
@@ -34,6 +36,7 @@
       },
       "required": [
         "name",
+        "properties",
         "apiVersion",
         "type"
       ],
@@ -294,6 +297,94 @@
     }
   },
   "definitions": {
+    "DiscriminatedUnionTestTypeProperties": {
+      "oneOf": [
+        {
+          "properties": {
+            "baz": {
+              "description": "The baz property",
+              "type": "string"
+            },
+            "quux": {
+              "description": "A property defined inline",
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "inherited"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "buzz": {
+              "description": "The buzz property",
+              "type": "string"
+            },
+            "fizz": {
+              "description": "The fizz property",
+              "type": "string"
+            },
+            "pop": {
+              "description": "The pop property",
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "inline"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "foo": {
+              "description": "The overridden foo property",
+              "oneOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+                }
+              ]
+            },
+            "type": {
+              "enum": [
+                "override"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object"
+        }
+      ],
+      "properties": {
+        "bar": {
+          "description": "The bar property",
+          "type": "string"
+        },
+        "foo": {
+          "description": "The foo property",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
     "EncryptionProperties": {
       "description": "Configuration of key for data encryption",
       "properties": {

--- a/src/autorest.bicep/test/integration/generated/arm-schema/firewalls/microsoft.network/2021-08-01/schema.json
+++ b/src/autorest.bicep/test/integration/generated/arm-schema/firewalls/microsoft.network/2021-08-01/schema.json
@@ -1,0 +1,1603 @@
+{
+  "id": "https://schema.management.azure.com/schemas/2021-08-01/Microsoft.Network.json#",
+  "title": "Microsoft.Network",
+  "description": "Microsoft Network Resource Types",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "resourceDefinitions": {
+    "firewallPolicies": {
+      "description": "Microsoft.Network/firewallPolicies",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2021-08-01"
+          ],
+          "type": "string"
+        },
+        "id": {
+          "description": "Resource ID.",
+          "type": "string"
+        },
+        "identity": {
+          "description": "The identity of the firewall policy.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ManagedServiceIdentity"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "location": {
+          "description": "Resource location.",
+          "type": "string"
+        },
+        "name": {
+          "description": "The name of the Firewall Policy.",
+          "type": "string"
+        },
+        "properties": {
+          "description": "Properties of the firewall policy.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/FirewallPolicyPropertiesFormat"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "resources": {
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/firewallPolicies_signatureOverrides_childResource"
+              },
+              {
+                "$ref": "#/definitions/firewallPolicies_ruleCollectionGroups_childResource"
+              }
+            ]
+          },
+          "type": "array"
+        },
+        "tags": {
+          "description": "Resource tags.",
+          "oneOf": [
+            {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {},
+              "type": "object"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.Network/firewallPolicies"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    },
+    "firewallPolicies_ruleCollectionGroups": {
+      "description": "Microsoft.Network/firewallPolicies/ruleCollectionGroups",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2021-08-01"
+          ],
+          "type": "string"
+        },
+        "id": {
+          "description": "Resource ID.",
+          "type": "string"
+        },
+        "name": {
+          "description": "The name of the FirewallPolicyRuleCollectionGroup.",
+          "type": "string"
+        },
+        "properties": {
+          "description": "The properties of the firewall policy rule collection group.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/FirewallPolicyRuleCollectionGroupProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.Network/firewallPolicies/ruleCollectionGroups"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    },
+    "firewallPolicies_signatureOverrides": {
+      "description": "Microsoft.Network/firewallPolicies/signatureOverrides",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2021-08-01"
+          ],
+          "type": "string"
+        },
+        "id": {
+          "description": "Will contain the resource id of the signature override resource",
+          "type": "string"
+        },
+        "name": {
+          "oneOf": [
+            {
+              "pattern": "^.*/default$",
+              "type": "string"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "properties": {
+          "description": "Will contain the properties of the resource (the actual signature overrides)",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/SignaturesOverridesProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "Microsoft.Network/firewallPolicies/signatureOverrides"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    }
+  },
+  "definitions": {
+    "Components1Jq1T4ISchemasManagedserviceidentityPropertiesUserassignedidentitiesAdditionalproperties": {
+      "properties": {},
+      "type": "object"
+    },
+    "DnsSettings": {
+      "description": "DNS Proxy Settings in Firewall Policy.",
+      "properties": {
+        "enableProxy": {
+          "description": "Enable DNS Proxy on Firewalls attached to the Firewall Policy.",
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "requireProxyForNetworkRules": {
+          "description": "FQDNs in Network Rules are supported when set to true.",
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "servers": {
+          "description": "List of Custom DNS Servers.",
+          "oneOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "ExplicitProxySettings": {
+      "description": "Explicit Proxy Settings in Firewall Policy.",
+      "properties": {
+        "enableExplicitProxy": {
+          "description": "When set to true, explicit proxy mode is enabled.",
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "httpPort": {
+          "description": "Port number for explicit proxy http protocol, cannot be greater than 64000.",
+          "oneOf": [
+            {
+              "maximum": 64000,
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "httpsPort": {
+          "description": "Port number for explicit proxy https protocol, cannot be greater than 64000.",
+          "oneOf": [
+            {
+              "maximum": 64000,
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "pacFile": {
+          "description": "SAS URL for PAC file.",
+          "type": "string"
+        },
+        "pacFilePort": {
+          "description": "Port number for firewall to serve PAC file.",
+          "oneOf": [
+            {
+              "maximum": 64000,
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "FirewallPolicyCertificateAuthority": {
+      "description": "Trusted Root certificates properties for tls.",
+      "properties": {
+        "keyVaultSecretId": {
+          "description": "Secret Id of (base-64 encoded unencrypted pfx) 'Secret' or 'Certificate' object stored in KeyVault.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the CA certificate.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "FirewallPolicyFilterRuleCollectionAction": {
+      "description": "Properties of the FirewallPolicyFilterRuleCollectionAction.",
+      "properties": {
+        "type": {
+          "description": "The type of action.",
+          "oneOf": [
+            {
+              "enum": [
+                "Allow",
+                "Deny"
+              ],
+              "type": "string"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "FirewallPolicyInsights": {
+      "description": "Firewall Policy Insights.",
+      "properties": {
+        "isEnabled": {
+          "description": "A flag to indicate if the insights are enabled on the policy.",
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "logAnalyticsResources": {
+          "description": "Workspaces needed to configure the Firewall Policy Insights.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/FirewallPolicyLogAnalyticsResources"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "retentionDays": {
+          "description": "Number of days the insights should be enabled on the policy.",
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "FirewallPolicyIntrusionDetection": {
+      "description": "Configuration for intrusion detection mode and rules.",
+      "properties": {
+        "configuration": {
+          "description": "Intrusion detection configuration properties.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/FirewallPolicyIntrusionDetectionConfiguration"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "mode": {
+          "description": "Intrusion detection general state.",
+          "oneOf": [
+            {
+              "enum": [
+                "Off",
+                "Alert",
+                "Deny"
+              ],
+              "type": "string"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "FirewallPolicyIntrusionDetectionBypassTrafficSpecifications": {
+      "description": "Intrusion detection bypass traffic specification.",
+      "properties": {
+        "description": {
+          "description": "Description of the bypass traffic rule.",
+          "type": "string"
+        },
+        "destinationAddresses": {
+          "description": "List of destination IP addresses or ranges for this rule.",
+          "oneOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "destinationIpGroups": {
+          "description": "List of destination IpGroups for this rule.",
+          "oneOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "destinationPorts": {
+          "description": "List of destination ports or ranges.",
+          "oneOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "name": {
+          "description": "Name of the bypass traffic rule.",
+          "type": "string"
+        },
+        "protocol": {
+          "description": "The rule bypass protocol.",
+          "oneOf": [
+            {
+              "enum": [
+                "TCP",
+                "UDP",
+                "ICMP",
+                "ANY"
+              ],
+              "type": "string"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "sourceAddresses": {
+          "description": "List of source IP addresses or ranges for this rule.",
+          "oneOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "sourceIpGroups": {
+          "description": "List of source IpGroups for this rule.",
+          "oneOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "FirewallPolicyIntrusionDetectionConfiguration": {
+      "description": "The operation for configuring intrusion detection.",
+      "properties": {
+        "bypassTrafficSettings": {
+          "description": "List of rules for traffic to bypass.",
+          "oneOf": [
+            {
+              "items": {
+                "$ref": "#/definitions/FirewallPolicyIntrusionDetectionBypassTrafficSpecifications"
+              },
+              "type": "array"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "privateRanges": {
+          "description": "IDPS Private IP address ranges are used to identify traffic direction (i.e. inbound, outbound, etc.). By default, only ranges defined by IANA RFC 1918 are considered private IP addresses. To modify default ranges, specify your Private IP address ranges with this property",
+          "oneOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "signatureOverrides": {
+          "description": "List of specific signatures states.",
+          "oneOf": [
+            {
+              "items": {
+                "$ref": "#/definitions/FirewallPolicyIntrusionDetectionSignatureSpecification"
+              },
+              "type": "array"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "FirewallPolicyIntrusionDetectionSignatureSpecification": {
+      "description": "Intrusion detection signatures specification states.",
+      "properties": {
+        "id": {
+          "description": "Signature id.",
+          "type": "string"
+        },
+        "mode": {
+          "description": "The signature state.",
+          "oneOf": [
+            {
+              "enum": [
+                "Off",
+                "Alert",
+                "Deny"
+              ],
+              "type": "string"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "FirewallPolicyLogAnalyticsResources": {
+      "description": "Log Analytics Resources for Firewall Policy Insights.",
+      "properties": {
+        "defaultWorkspaceId": {
+          "description": "The default workspace Id for Firewall Policy Insights.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/SubResource"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "workspaces": {
+          "description": "List of workspaces for Firewall Policy Insights.",
+          "oneOf": [
+            {
+              "items": {
+                "$ref": "#/definitions/FirewallPolicyLogAnalyticsWorkspace"
+              },
+              "type": "array"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "FirewallPolicyLogAnalyticsWorkspace": {
+      "description": "Log Analytics Workspace for Firewall Policy Insights.",
+      "properties": {
+        "region": {
+          "description": "Region to configure the Workspace.",
+          "type": "string"
+        },
+        "workspaceId": {
+          "description": "The workspace Id for Firewall Policy Insights.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/SubResource"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "FirewallPolicyNatRuleCollectionAction": {
+      "description": "Properties of the FirewallPolicyNatRuleCollectionAction.",
+      "properties": {
+        "type": {
+          "description": "The type of action.",
+          "oneOf": [
+            {
+              "enum": [
+                "DNAT"
+              ],
+              "type": "string"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "FirewallPolicyPropertiesFormat": {
+      "description": "Firewall Policy definition.",
+      "properties": {
+        "basePolicy": {
+          "description": "The parent firewall policy from which rules are inherited.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/SubResource"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "dnsSettings": {
+          "description": "DNS Proxy Settings definition.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/DnsSettings"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "explicitProxySettings": {
+          "description": "Explicit Proxy Settings definition.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/ExplicitProxySettings"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "insights": {
+          "description": "Insights on Firewall Policy.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/FirewallPolicyInsights"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "intrusionDetection": {
+          "description": "The configuration for Intrusion detection.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/FirewallPolicyIntrusionDetection"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "sku": {
+          "description": "The Firewall Policy SKU.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/FirewallPolicySku"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "snat": {
+          "description": "The private IP addresses/IP ranges to which traffic will not be SNAT.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/FirewallPolicySnat"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "sql": {
+          "description": "SQL Settings definition.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/FirewallPolicySQL"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "threatIntelMode": {
+          "description": "The operation mode for Threat Intelligence.",
+          "oneOf": [
+            {
+              "enum": [
+                "Alert",
+                "Deny",
+                "Off"
+              ],
+              "type": "string"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "threatIntelWhitelist": {
+          "description": "ThreatIntel Whitelist for Firewall Policy.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/FirewallPolicyThreatIntelWhitelist"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "transportSecurity": {
+          "description": "TLS Configuration definition.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/FirewallPolicyTransportSecurity"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "FirewallPolicyRule": {
+      "description": "Properties of a rule.",
+      "oneOf": [
+        {
+          "description": "Rule of type application.",
+          "properties": {
+            "destinationAddresses": {
+              "description": "List of destination IP addresses or Service Tags.",
+              "oneOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+                }
+              ]
+            },
+            "fqdnTags": {
+              "description": "List of FQDN Tags for this rule.",
+              "oneOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+                }
+              ]
+            },
+            "protocols": {
+              "description": "Array of Application Protocols.",
+              "oneOf": [
+                {
+                  "items": {
+                    "$ref": "#/definitions/FirewallPolicyRuleApplicationProtocol"
+                  },
+                  "type": "array"
+                },
+                {
+                  "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+                }
+              ]
+            },
+            "ruleType": {
+              "enum": [
+                "ApplicationRule"
+              ],
+              "type": "string"
+            },
+            "sourceAddresses": {
+              "description": "List of source IP addresses for this rule.",
+              "oneOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+                }
+              ]
+            },
+            "sourceIpGroups": {
+              "description": "List of source IpGroups for this rule.",
+              "oneOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+                }
+              ]
+            },
+            "targetFqdns": {
+              "description": "List of FQDNs for this rule.",
+              "oneOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+                }
+              ]
+            },
+            "targetUrls": {
+              "description": "List of Urls for this rule condition.",
+              "oneOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+                }
+              ]
+            },
+            "terminateTLS": {
+              "description": "Terminate TLS connections for this rule.",
+              "oneOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+                }
+              ]
+            },
+            "webCategories": {
+              "description": "List of destination azure web categories.",
+              "oneOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+                }
+              ]
+            }
+          },
+          "required": [
+            "ruleType"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Rule of type nat.",
+          "properties": {
+            "destinationAddresses": {
+              "description": "List of destination IP addresses or Service Tags.",
+              "oneOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+                }
+              ]
+            },
+            "destinationPorts": {
+              "description": "List of destination ports.",
+              "oneOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+                }
+              ]
+            },
+            "ipProtocols": {
+              "description": "Array of FirewallPolicyRuleNetworkProtocols.",
+              "oneOf": [
+                {
+                  "items": {
+                    "enum": [
+                      "TCP",
+                      "UDP",
+                      "Any",
+                      "ICMP"
+                    ],
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+                }
+              ]
+            },
+            "ruleType": {
+              "enum": [
+                "NatRule"
+              ],
+              "type": "string"
+            },
+            "sourceAddresses": {
+              "description": "List of source IP addresses for this rule.",
+              "oneOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+                }
+              ]
+            },
+            "sourceIpGroups": {
+              "description": "List of source IpGroups for this rule.",
+              "oneOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+                }
+              ]
+            },
+            "translatedAddress": {
+              "description": "The translated address for this NAT rule.",
+              "type": "string"
+            },
+            "translatedFqdn": {
+              "description": "The translated FQDN for this NAT rule.",
+              "type": "string"
+            },
+            "translatedPort": {
+              "description": "The translated port for this NAT rule.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "ruleType"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Rule of type network.",
+          "properties": {
+            "destinationAddresses": {
+              "description": "List of destination IP addresses or Service Tags.",
+              "oneOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+                }
+              ]
+            },
+            "destinationFqdns": {
+              "description": "List of destination FQDNs.",
+              "oneOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+                }
+              ]
+            },
+            "destinationIpGroups": {
+              "description": "List of destination IpGroups for this rule.",
+              "oneOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+                }
+              ]
+            },
+            "destinationPorts": {
+              "description": "List of destination ports.",
+              "oneOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+                }
+              ]
+            },
+            "ipProtocols": {
+              "description": "Array of FirewallPolicyRuleNetworkProtocols.",
+              "oneOf": [
+                {
+                  "items": {
+                    "enum": [
+                      "TCP",
+                      "UDP",
+                      "Any",
+                      "ICMP"
+                    ],
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+                }
+              ]
+            },
+            "ruleType": {
+              "enum": [
+                "NetworkRule"
+              ],
+              "type": "string"
+            },
+            "sourceAddresses": {
+              "description": "List of source IP addresses for this rule.",
+              "oneOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+                }
+              ]
+            },
+            "sourceIpGroups": {
+              "description": "List of source IpGroups for this rule.",
+              "oneOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+                }
+              ]
+            }
+          },
+          "required": [
+            "ruleType"
+          ],
+          "type": "object"
+        }
+      ],
+      "properties": {
+        "description": {
+          "description": "Description of the rule.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the rule.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "FirewallPolicyRuleApplicationProtocol": {
+      "description": "Properties of the application rule protocol.",
+      "properties": {
+        "port": {
+          "description": "Port number for the protocol, cannot be greater than 64000.",
+          "oneOf": [
+            {
+              "maximum": 64000,
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "protocolType": {
+          "description": "Protocol type.",
+          "oneOf": [
+            {
+              "enum": [
+                "Http",
+                "Https"
+              ],
+              "type": "string"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "FirewallPolicyRuleCollection": {
+      "description": "Properties of the rule collection.",
+      "oneOf": [
+        {
+          "description": "Firewall Policy Filter Rule Collection.",
+          "properties": {
+            "action": {
+              "description": "The action type of a Filter rule collection.",
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/FirewallPolicyFilterRuleCollectionAction"
+                },
+                {
+                  "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+                }
+              ]
+            },
+            "ruleCollectionType": {
+              "enum": [
+                "FirewallPolicyFilterRuleCollection"
+              ],
+              "type": "string"
+            },
+            "rules": {
+              "description": "List of rules included in a rule collection.",
+              "oneOf": [
+                {
+                  "items": {
+                    "$ref": "#/definitions/FirewallPolicyRule"
+                  },
+                  "type": "array"
+                },
+                {
+                  "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+                }
+              ]
+            }
+          },
+          "required": [
+            "ruleCollectionType"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Firewall Policy NAT Rule Collection.",
+          "properties": {
+            "action": {
+              "description": "The action type of a Nat rule collection.",
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/FirewallPolicyNatRuleCollectionAction"
+                },
+                {
+                  "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+                }
+              ]
+            },
+            "ruleCollectionType": {
+              "enum": [
+                "FirewallPolicyNatRuleCollection"
+              ],
+              "type": "string"
+            },
+            "rules": {
+              "description": "List of rules included in a rule collection.",
+              "oneOf": [
+                {
+                  "items": {
+                    "$ref": "#/definitions/FirewallPolicyRule"
+                  },
+                  "type": "array"
+                },
+                {
+                  "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+                }
+              ]
+            }
+          },
+          "required": [
+            "ruleCollectionType"
+          ],
+          "type": "object"
+        }
+      ],
+      "properties": {
+        "name": {
+          "description": "The name of the rule collection.",
+          "type": "string"
+        },
+        "priority": {
+          "description": "Priority of the Firewall Policy Rule Collection resource.",
+          "oneOf": [
+            {
+              "maximum": 65000,
+              "minimum": 100,
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "FirewallPolicyRuleCollectionGroupProperties": {
+      "description": "Properties of the rule collection group.",
+      "properties": {
+        "priority": {
+          "description": "Priority of the Firewall Policy Rule Collection Group resource.",
+          "oneOf": [
+            {
+              "maximum": 65000,
+              "minimum": 100,
+              "type": "integer"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "ruleCollections": {
+          "description": "Group of Firewall Policy rule collections.",
+          "oneOf": [
+            {
+              "items": {
+                "$ref": "#/definitions/FirewallPolicyRuleCollection"
+              },
+              "type": "array"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "FirewallPolicySQL": {
+      "description": "SQL Settings in Firewall Policy.",
+      "properties": {
+        "allowSqlRedirect": {
+          "description": "A flag to indicate if SQL Redirect traffic filtering is enabled. Turning on the flag requires no rule using port 11000-11999.",
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "FirewallPolicySku": {
+      "description": "SKU of Firewall policy.",
+      "properties": {
+        "tier": {
+          "description": "Tier of Firewall Policy.",
+          "oneOf": [
+            {
+              "enum": [
+                "Standard",
+                "Premium",
+                "Basic"
+              ],
+              "type": "string"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "FirewallPolicySnat": {
+      "description": "The private IP addresses/IP ranges to which traffic will not be SNAT.",
+      "properties": {
+        "privateRanges": {
+          "description": "List of private IP addresses/IP address ranges to not be SNAT.",
+          "oneOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "FirewallPolicyThreatIntelWhitelist": {
+      "description": "ThreatIntel Whitelist for Firewall Policy.",
+      "properties": {
+        "fqdns": {
+          "description": "List of FQDNs for the ThreatIntel Whitelist.",
+          "oneOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "ipAddresses": {
+          "description": "List of IP addresses for the ThreatIntel Whitelist.",
+          "oneOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "FirewallPolicyTransportSecurity": {
+      "description": "Configuration needed to perform TLS termination & initiation.",
+      "properties": {
+        "certificateAuthority": {
+          "description": "The CA used for intermediate CA generation.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/FirewallPolicyCertificateAuthority"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "ManagedServiceIdentity": {
+      "description": "Identity for the resource.",
+      "properties": {
+        "type": {
+          "description": "The type of identity used for the resource. The type 'SystemAssigned, UserAssigned' includes both an implicitly created identity and a set of user assigned identities. The type 'None' will remove any identities from the virtual machine.",
+          "oneOf": [
+            {
+              "enum": [
+                "SystemAssigned",
+                "UserAssigned",
+                "SystemAssigned, UserAssigned",
+                "None"
+              ],
+              "type": "string"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "userAssignedIdentities": {
+          "description": "The list of user identities associated with resource. The user identity dictionary key references will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'.",
+          "oneOf": [
+            {
+              "additionalProperties": {
+                "$ref": "#/definitions/Components1Jq1T4ISchemasManagedserviceidentityPropertiesUserassignedidentitiesAdditionalproperties"
+              },
+              "properties": {},
+              "type": "object"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "SignaturesOverridesProperties": {
+      "description": "Will contain the properties of the resource (the actual signature overrides)",
+      "properties": {
+        "signatures": {
+          "description": "Dictionary of <string>",
+          "oneOf": [
+            {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "properties": {},
+              "type": "object"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "SubResource": {
+      "description": "Reference to another subresource.",
+      "properties": {
+        "id": {
+          "description": "Resource ID.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "firewallPolicies_ruleCollectionGroups_childResource": {
+      "description": "Microsoft.Network/firewallPolicies/ruleCollectionGroups",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2021-08-01"
+          ],
+          "type": "string"
+        },
+        "id": {
+          "description": "Resource ID.",
+          "type": "string"
+        },
+        "name": {
+          "description": "The name of the FirewallPolicyRuleCollectionGroup.",
+          "type": "string"
+        },
+        "properties": {
+          "description": "The properties of the firewall policy rule collection group.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/FirewallPolicyRuleCollectionGroupProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "ruleCollectionGroups"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    },
+    "firewallPolicies_signatureOverrides_childResource": {
+      "description": "Microsoft.Network/firewallPolicies/signatureOverrides",
+      "properties": {
+        "apiVersion": {
+          "enum": [
+            "2021-08-01"
+          ],
+          "type": "string"
+        },
+        "id": {
+          "description": "Will contain the resource id of the signature override resource",
+          "type": "string"
+        },
+        "name": {
+          "oneOf": [
+            {
+              "enum": [
+                "default"
+              ],
+              "type": "string"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "properties": {
+          "description": "Will contain the properties of the resource (the actual signature overrides)",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/SignaturesOverridesProperties"
+            },
+            {
+              "$ref": "https://schema.management.azure.com/schemas/common/definitions.json#/definitions/expression"
+            }
+          ]
+        },
+        "type": {
+          "enum": [
+            "signatureOverrides"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties",
+        "apiVersion",
+        "type"
+      ],
+      "type": "object"
+    }
+  }
+}

--- a/src/autorest.bicep/test/integration/generated/bicep/basic/test.rp1/2021-10-31/types.json
+++ b/src/autorest.bicep/test/integration/generated/bicep/basic/test.rp1/2021-10-31/types.json
@@ -805,10 +805,9 @@
     "value": "2021-10-31"
   },
   {
-    "$type": "DiscriminatedObjectType",
+    "$type": "ObjectType",
     "name": "Test.Rp1/discriminatedUnionTestType",
-    "discriminator": "type",
-    "baseProperties": {
+    "properties": {
       "id": {
         "type": {
           "$ref": "#/2"
@@ -837,6 +836,19 @@
         "flags": 10,
         "description": "The resource api version"
       },
+      "properties": {
+        "type": {
+          "$ref": "#/63"
+        },
+        "flags": 1
+      }
+    }
+  },
+  {
+    "$type": "DiscriminatedObjectType",
+    "name": "DiscriminatedUnionTestTypeProperties",
+    "discriminator": "type",
+    "baseProperties": {
       "bar": {
         "type": {
           "$ref": "#/2"
@@ -854,19 +866,19 @@
     },
     "elements": {
       "inherited": {
-        "$ref": "#/63"
+        "$ref": "#/64"
       },
       "inline": {
-        "$ref": "#/65"
+        "$ref": "#/66"
       },
       "override": {
-        "$ref": "#/67"
+        "$ref": "#/68"
       }
     }
   },
   {
     "$type": "ObjectType",
-    "name": "DiscriminatedUnionTestTypeBranchWithInheritedProps",
+    "name": "DiscriminatedUnionTestTypePropertiesBranchWithInheritedProps",
     "properties": {
       "quux": {
         "type": {
@@ -884,7 +896,7 @@
       },
       "type": {
         "type": {
-          "$ref": "#/64"
+          "$ref": "#/65"
         },
         "flags": 1,
         "description": "The variant of this type"
@@ -897,7 +909,7 @@
   },
   {
     "$type": "ObjectType",
-    "name": "DiscriminatedUnionTestTypeBranchWithAllInlineProps",
+    "name": "DiscriminatedUnionTestTypePropertiesBranchWithAllInlineProps",
     "properties": {
       "fizz": {
         "type": {
@@ -922,7 +934,7 @@
       },
       "type": {
         "type": {
-          "$ref": "#/66"
+          "$ref": "#/67"
         },
         "flags": 1,
         "description": "The variant of this type"
@@ -935,18 +947,18 @@
   },
   {
     "$type": "ObjectType",
-    "name": "DiscriminatedUnionTestTypeBranchWithOverride",
+    "name": "DiscriminatedUnionTestTypePropertiesBranchWithOverride",
     "properties": {
       "foo": {
         "type": {
-          "$ref": "#/68"
+          "$ref": "#/69"
         },
         "flags": 0,
         "description": "The overridden foo property"
       },
       "type": {
         "type": {
-          "$ref": "#/69"
+          "$ref": "#/70"
         },
         "flags": 1,
         "description": "The variant of this type"
@@ -997,27 +1009,27 @@
       },
       "type": {
         "type": {
-          "$ref": "#/71"
+          "$ref": "#/72"
         },
         "flags": 10,
         "description": "The resource type"
       },
       "apiVersion": {
         "type": {
-          "$ref": "#/72"
+          "$ref": "#/73"
         },
         "flags": 10,
         "description": "The resource api version"
       },
       "properties": {
         "type": {
-          "$ref": "#/74"
+          "$ref": "#/75"
         },
         "flags": 2
       },
       "tags": {
         "type": {
-          "$ref": "#/76"
+          "$ref": "#/77"
         },
         "flags": 2,
         "description": "Resource tags."
@@ -1044,7 +1056,7 @@
     "properties": {
       "plan": {
         "type": {
-          "$ref": "#/75"
+          "$ref": "#/76"
         },
         "flags": 0,
         "description": "Plan for the resource."
@@ -1105,7 +1117,7 @@
     "name": "Test.Rp1/readOnlyTestType@2021-10-31",
     "scopeType": 8,
     "body": {
-      "$ref": "#/73"
+      "$ref": "#/74"
     },
     "flags": 1
   },
@@ -1148,16 +1160,16 @@
     "resourceType": "Test.Rp1/testType1",
     "apiVersion": "2021-10-31",
     "output": {
-      "$ref": "#/79"
+      "$ref": "#/80"
     },
     "input": {
-      "$ref": "#/78"
+      "$ref": "#/79"
     }
   },
   {
     "$type": "ArrayType",
     "itemType": {
-      "$ref": "#/79"
+      "$ref": "#/80"
     },
     "minLength": 1,
     "maxLength": 10
@@ -1168,7 +1180,7 @@
     "resourceType": "Test.Rp1/testType1",
     "apiVersion": "2021-10-31",
     "output": {
-      "$ref": "#/81"
+      "$ref": "#/82"
     }
   }
 ]

--- a/src/autorest.bicep/test/integration/generated/bicep/basic/test.rp1/2021-10-31/types.md
+++ b/src/autorest.bicep/test/integration/generated/bicep/basic/test.rp1/2021-10-31/types.md
@@ -2,34 +2,12 @@
 
 ## Resource Test.Rp1/discriminatedUnionTestType@2021-10-31
 * **Valid Scope(s)**: ResourceGroup
-* **Discriminator**: type
-
-### Base Properties
+### Properties
 * **apiVersion**: '2021-10-31' (ReadOnly, DeployTimeConstant): The resource api version
-* **bar**: string: The bar property
-* **foo**: string: The foo property
 * **id**: string (ReadOnly, DeployTimeConstant): The resource id
 * **name**: string (Required, DeployTimeConstant): The resource name
+* **properties**: [DiscriminatedUnionTestTypeProperties](#discriminateduniontesttypeproperties) (Required)
 * **type**: 'Test.Rp1/discriminatedUnionTestType' (ReadOnly, DeployTimeConstant): The resource type
-
-### DiscriminatedUnionTestTypeBranchWithInheritedProps
-#### Properties
-* **baz**: string: The baz property
-* **quux**: string: A property defined inline
-* **type**: 'inherited' (Required): The variant of this type
-
-### DiscriminatedUnionTestTypeBranchWithAllInlineProps
-#### Properties
-* **buzz**: string: The buzz property
-* **fizz**: string: The fizz property
-* **pop**: string: The pop property
-* **type**: 'inline' (Required): The variant of this type
-
-### DiscriminatedUnionTestTypeBranchWithOverride
-#### Properties
-* **foo**: int: The overridden foo property
-* **type**: 'override' (Required): The variant of this type
-
 
 ## Resource Test.Rp1/partlyReadonlyType@2021-10-31
 * **Valid Scope(s)**: Tenant (ReadOnly), ResourceGroup
@@ -89,6 +67,32 @@
 * **ApiVersion**: 2021-10-31
 * **Input**: [FoosRequest](#foosrequest)
 * **Output**: [FoosResponse](#foosresponse)
+
+## DiscriminatedUnionTestTypeProperties
+* **Discriminator**: type
+
+### Base Properties
+* **bar**: string: The bar property
+* **foo**: string: The foo property
+
+### DiscriminatedUnionTestTypePropertiesBranchWithInheritedProps
+#### Properties
+* **baz**: string: The baz property
+* **quux**: string: A property defined inline
+* **type**: 'inherited' (Required): The variant of this type
+
+### DiscriminatedUnionTestTypePropertiesBranchWithAllInlineProps
+#### Properties
+* **buzz**: string: The buzz property
+* **fizz**: string: The fizz property
+* **pop**: string: The pop property
+* **type**: 'inline' (Required): The variant of this type
+
+### DiscriminatedUnionTestTypePropertiesBranchWithOverride
+#### Properties
+* **foo**: int: The overridden foo property
+* **type**: 'override' (Required): The variant of this type
+
 
 ## EncryptionProperties
 ### Properties

--- a/src/autorest.bicep/test/integration/generated/bicep/firewalls/microsoft.network/2021-08-01/types.json
+++ b/src/autorest.bicep/test/integration/generated/bicep/firewalls/microsoft.network/2021-08-01/types.json
@@ -1,0 +1,2139 @@
+[
+  {
+    "$type": "StringType"
+  },
+  {
+    "$type": "StringLiteralType",
+    "value": "Microsoft.Network/firewallPolicies"
+  },
+  {
+    "$type": "StringLiteralType",
+    "value": "2021-08-01"
+  },
+  {
+    "$type": "ObjectType",
+    "name": "Microsoft.Network/firewallPolicies",
+    "properties": {
+      "id": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 10,
+        "description": "The resource id"
+      },
+      "name": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 9,
+        "description": "The resource name"
+      },
+      "type": {
+        "type": {
+          "$ref": "#/1"
+        },
+        "flags": 10,
+        "description": "The resource type"
+      },
+      "apiVersion": {
+        "type": {
+          "$ref": "#/2"
+        },
+        "flags": 10,
+        "description": "The resource api version"
+      },
+      "properties": {
+        "type": {
+          "$ref": "#/4"
+        },
+        "flags": 0,
+        "description": "Properties of the firewall policy."
+      },
+      "etag": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 2,
+        "description": "A unique read-only string that changes whenever the resource is updated."
+      },
+      "identity": {
+        "type": {
+          "$ref": "#/66"
+        },
+        "flags": 0,
+        "description": "The identity of the firewall policy."
+      },
+      "location": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 0,
+        "description": "Resource location."
+      },
+      "tags": {
+        "type": {
+          "$ref": "#/74"
+        },
+        "flags": 0,
+        "description": "Resource tags."
+      }
+    }
+  },
+  {
+    "$type": "ObjectType",
+    "name": "FirewallPolicyPropertiesFormat",
+    "properties": {
+      "ruleCollectionGroups": {
+        "type": {
+          "$ref": "#/6"
+        },
+        "flags": 2,
+        "description": "List of references to FirewallPolicyRuleCollectionGroups."
+      },
+      "provisioningState": {
+        "type": {
+          "$ref": "#/11"
+        },
+        "flags": 2,
+        "description": "The provisioning state of the firewall policy resource."
+      },
+      "basePolicy": {
+        "type": {
+          "$ref": "#/5"
+        },
+        "flags": 0,
+        "description": "The parent firewall policy from which rules are inherited."
+      },
+      "firewalls": {
+        "type": {
+          "$ref": "#/12"
+        },
+        "flags": 2,
+        "description": "List of references to Azure Firewalls that this Firewall Policy is associated with."
+      },
+      "childPolicies": {
+        "type": {
+          "$ref": "#/13"
+        },
+        "flags": 2,
+        "description": "List of references to Child Firewall Policies."
+      },
+      "threatIntelMode": {
+        "type": {
+          "$ref": "#/17"
+        },
+        "flags": 0,
+        "description": "The operation mode for Threat Intelligence."
+      },
+      "threatIntelWhitelist": {
+        "type": {
+          "$ref": "#/18"
+        },
+        "flags": 0,
+        "description": "ThreatIntel Whitelist for Firewall Policy."
+      },
+      "insights": {
+        "type": {
+          "$ref": "#/21"
+        },
+        "flags": 0,
+        "description": "Insights on Firewall Policy."
+      },
+      "snat": {
+        "type": {
+          "$ref": "#/27"
+        },
+        "flags": 0,
+        "description": "The private IP addresses/IP ranges to which traffic will not be SNAT."
+      },
+      "sql": {
+        "type": {
+          "$ref": "#/29"
+        },
+        "flags": 0,
+        "description": "SQL Settings definition."
+      },
+      "dnsSettings": {
+        "type": {
+          "$ref": "#/30"
+        },
+        "flags": 0,
+        "description": "DNS Proxy Settings definition."
+      },
+      "explicitProxySettings": {
+        "type": {
+          "$ref": "#/32"
+        },
+        "flags": 0,
+        "description": "Explicit Proxy Settings definition."
+      },
+      "intrusionDetection": {
+        "type": {
+          "$ref": "#/34"
+        },
+        "flags": 0,
+        "description": "The configuration for Intrusion detection."
+      },
+      "transportSecurity": {
+        "type": {
+          "$ref": "#/59"
+        },
+        "flags": 0,
+        "description": "TLS Configuration definition."
+      },
+      "sku": {
+        "type": {
+          "$ref": "#/61"
+        },
+        "flags": 0,
+        "description": "The Firewall Policy SKU."
+      }
+    }
+  },
+  {
+    "$type": "ObjectType",
+    "name": "SubResource",
+    "properties": {
+      "id": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 0,
+        "description": "Resource ID."
+      }
+    }
+  },
+  {
+    "$type": "ArrayType",
+    "itemType": {
+      "$ref": "#/5"
+    }
+  },
+  {
+    "$type": "StringLiteralType",
+    "value": "Succeeded"
+  },
+  {
+    "$type": "StringLiteralType",
+    "value": "Updating"
+  },
+  {
+    "$type": "StringLiteralType",
+    "value": "Deleting"
+  },
+  {
+    "$type": "StringLiteralType",
+    "value": "Failed"
+  },
+  {
+    "$type": "UnionType",
+    "elements": [
+      {
+        "$ref": "#/7"
+      },
+      {
+        "$ref": "#/8"
+      },
+      {
+        "$ref": "#/9"
+      },
+      {
+        "$ref": "#/10"
+      },
+      {
+        "$ref": "#/0"
+      }
+    ]
+  },
+  {
+    "$type": "ArrayType",
+    "itemType": {
+      "$ref": "#/5"
+    }
+  },
+  {
+    "$type": "ArrayType",
+    "itemType": {
+      "$ref": "#/5"
+    }
+  },
+  {
+    "$type": "StringLiteralType",
+    "value": "Alert"
+  },
+  {
+    "$type": "StringLiteralType",
+    "value": "Deny"
+  },
+  {
+    "$type": "StringLiteralType",
+    "value": "Off"
+  },
+  {
+    "$type": "UnionType",
+    "elements": [
+      {
+        "$ref": "#/14"
+      },
+      {
+        "$ref": "#/15"
+      },
+      {
+        "$ref": "#/16"
+      },
+      {
+        "$ref": "#/0"
+      }
+    ]
+  },
+  {
+    "$type": "ObjectType",
+    "name": "FirewallPolicyThreatIntelWhitelist",
+    "properties": {
+      "ipAddresses": {
+        "type": {
+          "$ref": "#/19"
+        },
+        "flags": 0,
+        "description": "List of IP addresses for the ThreatIntel Whitelist."
+      },
+      "fqdns": {
+        "type": {
+          "$ref": "#/20"
+        },
+        "flags": 0,
+        "description": "List of FQDNs for the ThreatIntel Whitelist."
+      }
+    }
+  },
+  {
+    "$type": "ArrayType",
+    "itemType": {
+      "$ref": "#/0"
+    }
+  },
+  {
+    "$type": "ArrayType",
+    "itemType": {
+      "$ref": "#/0"
+    }
+  },
+  {
+    "$type": "ObjectType",
+    "name": "FirewallPolicyInsights",
+    "properties": {
+      "isEnabled": {
+        "type": {
+          "$ref": "#/22"
+        },
+        "flags": 0,
+        "description": "A flag to indicate if the insights are enabled on the policy."
+      },
+      "retentionDays": {
+        "type": {
+          "$ref": "#/23"
+        },
+        "flags": 0,
+        "description": "Number of days the insights should be enabled on the policy."
+      },
+      "logAnalyticsResources": {
+        "type": {
+          "$ref": "#/24"
+        },
+        "flags": 0,
+        "description": "Workspaces needed to configure the Firewall Policy Insights."
+      }
+    }
+  },
+  {
+    "$type": "BooleanType"
+  },
+  {
+    "$type": "IntegerType"
+  },
+  {
+    "$type": "ObjectType",
+    "name": "FirewallPolicyLogAnalyticsResources",
+    "properties": {
+      "workspaces": {
+        "type": {
+          "$ref": "#/26"
+        },
+        "flags": 0,
+        "description": "List of workspaces for Firewall Policy Insights."
+      },
+      "defaultWorkspaceId": {
+        "type": {
+          "$ref": "#/5"
+        },
+        "flags": 0,
+        "description": "The default workspace Id for Firewall Policy Insights."
+      }
+    }
+  },
+  {
+    "$type": "ObjectType",
+    "name": "FirewallPolicyLogAnalyticsWorkspace",
+    "properties": {
+      "region": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 0,
+        "description": "Region to configure the Workspace."
+      },
+      "workspaceId": {
+        "type": {
+          "$ref": "#/5"
+        },
+        "flags": 0,
+        "description": "The workspace Id for Firewall Policy Insights."
+      }
+    }
+  },
+  {
+    "$type": "ArrayType",
+    "itemType": {
+      "$ref": "#/25"
+    }
+  },
+  {
+    "$type": "ObjectType",
+    "name": "FirewallPolicySnat",
+    "properties": {
+      "privateRanges": {
+        "type": {
+          "$ref": "#/28"
+        },
+        "flags": 0,
+        "description": "List of private IP addresses/IP address ranges to not be SNAT."
+      }
+    }
+  },
+  {
+    "$type": "ArrayType",
+    "itemType": {
+      "$ref": "#/0"
+    }
+  },
+  {
+    "$type": "ObjectType",
+    "name": "FirewallPolicySQL",
+    "properties": {
+      "allowSqlRedirect": {
+        "type": {
+          "$ref": "#/22"
+        },
+        "flags": 0,
+        "description": "A flag to indicate if SQL Redirect traffic filtering is enabled. Turning on the flag requires no rule using port 11000-11999."
+      }
+    }
+  },
+  {
+    "$type": "ObjectType",
+    "name": "DnsSettings",
+    "properties": {
+      "servers": {
+        "type": {
+          "$ref": "#/31"
+        },
+        "flags": 0,
+        "description": "List of Custom DNS Servers."
+      },
+      "enableProxy": {
+        "type": {
+          "$ref": "#/22"
+        },
+        "flags": 0,
+        "description": "Enable DNS Proxy on Firewalls attached to the Firewall Policy."
+      },
+      "requireProxyForNetworkRules": {
+        "type": {
+          "$ref": "#/22"
+        },
+        "flags": 0,
+        "description": "FQDNs in Network Rules are supported when set to true."
+      }
+    }
+  },
+  {
+    "$type": "ArrayType",
+    "itemType": {
+      "$ref": "#/0"
+    }
+  },
+  {
+    "$type": "ObjectType",
+    "name": "ExplicitProxySettings",
+    "properties": {
+      "enableExplicitProxy": {
+        "type": {
+          "$ref": "#/22"
+        },
+        "flags": 0,
+        "description": "When set to true, explicit proxy mode is enabled."
+      },
+      "httpPort": {
+        "type": {
+          "$ref": "#/33"
+        },
+        "flags": 0,
+        "description": "Port number for explicit proxy http protocol, cannot be greater than 64000."
+      },
+      "httpsPort": {
+        "type": {
+          "$ref": "#/33"
+        },
+        "flags": 0,
+        "description": "Port number for explicit proxy https protocol, cannot be greater than 64000."
+      },
+      "pacFilePort": {
+        "type": {
+          "$ref": "#/33"
+        },
+        "flags": 0,
+        "description": "Port number for firewall to serve PAC file."
+      },
+      "pacFile": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 0,
+        "description": "SAS URL for PAC file."
+      }
+    }
+  },
+  {
+    "$type": "IntegerType",
+    "minValue": 0,
+    "maxValue": 64000
+  },
+  {
+    "$type": "ObjectType",
+    "name": "FirewallPolicyIntrusionDetection",
+    "properties": {
+      "mode": {
+        "type": {
+          "$ref": "#/38"
+        },
+        "flags": 0,
+        "description": "Intrusion detection general state."
+      },
+      "configuration": {
+        "type": {
+          "$ref": "#/39"
+        },
+        "flags": 0,
+        "description": "Intrusion detection configuration properties."
+      }
+    }
+  },
+  {
+    "$type": "StringLiteralType",
+    "value": "Off"
+  },
+  {
+    "$type": "StringLiteralType",
+    "value": "Alert"
+  },
+  {
+    "$type": "StringLiteralType",
+    "value": "Deny"
+  },
+  {
+    "$type": "UnionType",
+    "elements": [
+      {
+        "$ref": "#/35"
+      },
+      {
+        "$ref": "#/36"
+      },
+      {
+        "$ref": "#/37"
+      },
+      {
+        "$ref": "#/0"
+      }
+    ]
+  },
+  {
+    "$type": "ObjectType",
+    "name": "FirewallPolicyIntrusionDetectionConfiguration",
+    "properties": {
+      "signatureOverrides": {
+        "type": {
+          "$ref": "#/45"
+        },
+        "flags": 0,
+        "description": "List of specific signatures states."
+      },
+      "bypassTrafficSettings": {
+        "type": {
+          "$ref": "#/57"
+        },
+        "flags": 0,
+        "description": "List of rules for traffic to bypass."
+      },
+      "privateRanges": {
+        "type": {
+          "$ref": "#/58"
+        },
+        "flags": 0,
+        "description": "IDPS Private IP address ranges are used to identify traffic direction (i.e. inbound, outbound, etc.). By default, only ranges defined by IANA RFC 1918 are considered private IP addresses. To modify default ranges, specify your Private IP address ranges with this property"
+      }
+    }
+  },
+  {
+    "$type": "ObjectType",
+    "name": "FirewallPolicyIntrusionDetectionSignatureSpecification",
+    "properties": {
+      "id": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 0,
+        "description": "Signature id."
+      },
+      "mode": {
+        "type": {
+          "$ref": "#/44"
+        },
+        "flags": 0,
+        "description": "The signature state."
+      }
+    }
+  },
+  {
+    "$type": "StringLiteralType",
+    "value": "Off"
+  },
+  {
+    "$type": "StringLiteralType",
+    "value": "Alert"
+  },
+  {
+    "$type": "StringLiteralType",
+    "value": "Deny"
+  },
+  {
+    "$type": "UnionType",
+    "elements": [
+      {
+        "$ref": "#/41"
+      },
+      {
+        "$ref": "#/42"
+      },
+      {
+        "$ref": "#/43"
+      },
+      {
+        "$ref": "#/0"
+      }
+    ]
+  },
+  {
+    "$type": "ArrayType",
+    "itemType": {
+      "$ref": "#/40"
+    }
+  },
+  {
+    "$type": "ObjectType",
+    "name": "FirewallPolicyIntrusionDetectionBypassTrafficSpecifications",
+    "properties": {
+      "name": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 0,
+        "description": "Name of the bypass traffic rule."
+      },
+      "description": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 0,
+        "description": "Description of the bypass traffic rule."
+      },
+      "protocol": {
+        "type": {
+          "$ref": "#/51"
+        },
+        "flags": 0,
+        "description": "The rule bypass protocol."
+      },
+      "sourceAddresses": {
+        "type": {
+          "$ref": "#/52"
+        },
+        "flags": 0,
+        "description": "List of source IP addresses or ranges for this rule."
+      },
+      "destinationAddresses": {
+        "type": {
+          "$ref": "#/53"
+        },
+        "flags": 0,
+        "description": "List of destination IP addresses or ranges for this rule."
+      },
+      "destinationPorts": {
+        "type": {
+          "$ref": "#/54"
+        },
+        "flags": 0,
+        "description": "List of destination ports or ranges."
+      },
+      "sourceIpGroups": {
+        "type": {
+          "$ref": "#/55"
+        },
+        "flags": 0,
+        "description": "List of source IpGroups for this rule."
+      },
+      "destinationIpGroups": {
+        "type": {
+          "$ref": "#/56"
+        },
+        "flags": 0,
+        "description": "List of destination IpGroups for this rule."
+      }
+    }
+  },
+  {
+    "$type": "StringLiteralType",
+    "value": "TCP"
+  },
+  {
+    "$type": "StringLiteralType",
+    "value": "UDP"
+  },
+  {
+    "$type": "StringLiteralType",
+    "value": "ICMP"
+  },
+  {
+    "$type": "StringLiteralType",
+    "value": "ANY"
+  },
+  {
+    "$type": "UnionType",
+    "elements": [
+      {
+        "$ref": "#/47"
+      },
+      {
+        "$ref": "#/48"
+      },
+      {
+        "$ref": "#/49"
+      },
+      {
+        "$ref": "#/50"
+      },
+      {
+        "$ref": "#/0"
+      }
+    ]
+  },
+  {
+    "$type": "ArrayType",
+    "itemType": {
+      "$ref": "#/0"
+    }
+  },
+  {
+    "$type": "ArrayType",
+    "itemType": {
+      "$ref": "#/0"
+    }
+  },
+  {
+    "$type": "ArrayType",
+    "itemType": {
+      "$ref": "#/0"
+    }
+  },
+  {
+    "$type": "ArrayType",
+    "itemType": {
+      "$ref": "#/0"
+    }
+  },
+  {
+    "$type": "ArrayType",
+    "itemType": {
+      "$ref": "#/0"
+    }
+  },
+  {
+    "$type": "ArrayType",
+    "itemType": {
+      "$ref": "#/46"
+    }
+  },
+  {
+    "$type": "ArrayType",
+    "itemType": {
+      "$ref": "#/0"
+    }
+  },
+  {
+    "$type": "ObjectType",
+    "name": "FirewallPolicyTransportSecurity",
+    "properties": {
+      "certificateAuthority": {
+        "type": {
+          "$ref": "#/60"
+        },
+        "flags": 0,
+        "description": "The CA used for intermediate CA generation."
+      }
+    }
+  },
+  {
+    "$type": "ObjectType",
+    "name": "FirewallPolicyCertificateAuthority",
+    "properties": {
+      "keyVaultSecretId": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 0,
+        "description": "Secret Id of (base-64 encoded unencrypted pfx) 'Secret' or 'Certificate' object stored in KeyVault."
+      },
+      "name": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 0,
+        "description": "Name of the CA certificate."
+      }
+    }
+  },
+  {
+    "$type": "ObjectType",
+    "name": "FirewallPolicySku",
+    "properties": {
+      "tier": {
+        "type": {
+          "$ref": "#/65"
+        },
+        "flags": 0,
+        "description": "Tier of Firewall Policy."
+      }
+    }
+  },
+  {
+    "$type": "StringLiteralType",
+    "value": "Standard"
+  },
+  {
+    "$type": "StringLiteralType",
+    "value": "Premium"
+  },
+  {
+    "$type": "StringLiteralType",
+    "value": "Basic"
+  },
+  {
+    "$type": "UnionType",
+    "elements": [
+      {
+        "$ref": "#/62"
+      },
+      {
+        "$ref": "#/63"
+      },
+      {
+        "$ref": "#/64"
+      },
+      {
+        "$ref": "#/0"
+      }
+    ]
+  },
+  {
+    "$type": "ObjectType",
+    "name": "ManagedServiceIdentity",
+    "properties": {
+      "principalId": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 2,
+        "description": "The principal id of the system assigned identity. This property will only be provided for a system assigned identity."
+      },
+      "tenantId": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 2,
+        "description": "The tenant id of the system assigned identity. This property will only be provided for a system assigned identity."
+      },
+      "type": {
+        "type": {
+          "$ref": "#/71"
+        },
+        "flags": 0,
+        "description": "The type of identity used for the resource. The type 'SystemAssigned, UserAssigned' includes both an implicitly created identity and a set of user assigned identities. The type 'None' will remove any identities from the virtual machine."
+      },
+      "userAssignedIdentities": {
+        "type": {
+          "$ref": "#/73"
+        },
+        "flags": 0,
+        "description": "The list of user identities associated with resource. The user identity dictionary key references will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'."
+      }
+    }
+  },
+  {
+    "$type": "StringLiteralType",
+    "value": "SystemAssigned"
+  },
+  {
+    "$type": "StringLiteralType",
+    "value": "UserAssigned"
+  },
+  {
+    "$type": "StringLiteralType",
+    "value": "SystemAssigned, UserAssigned"
+  },
+  {
+    "$type": "StringLiteralType",
+    "value": "None"
+  },
+  {
+    "$type": "UnionType",
+    "elements": [
+      {
+        "$ref": "#/67"
+      },
+      {
+        "$ref": "#/68"
+      },
+      {
+        "$ref": "#/69"
+      },
+      {
+        "$ref": "#/70"
+      }
+    ]
+  },
+  {
+    "$type": "ObjectType",
+    "name": "Components1Jq1T4ISchemasManagedserviceidentityPropertiesUserassignedidentitiesAdditionalproperties",
+    "properties": {
+      "principalId": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 2,
+        "description": "The principal id of user assigned identity."
+      },
+      "clientId": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 2,
+        "description": "The client id of user assigned identity."
+      }
+    }
+  },
+  {
+    "$type": "ObjectType",
+    "name": "ManagedServiceIdentityUserAssignedIdentities",
+    "properties": {},
+    "additionalProperties": {
+      "$ref": "#/72"
+    }
+  },
+  {
+    "$type": "ObjectType",
+    "name": "ResourceTags",
+    "properties": {},
+    "additionalProperties": {
+      "$ref": "#/0"
+    }
+  },
+  {
+    "$type": "ResourceType",
+    "name": "Microsoft.Network/firewallPolicies@2021-08-01",
+    "scopeType": 8,
+    "body": {
+      "$ref": "#/3"
+    },
+    "flags": 0
+  },
+  {
+    "$type": "StringLiteralType",
+    "value": "Microsoft.Network/firewallPolicies/ruleCollectionGroups"
+  },
+  {
+    "$type": "StringLiteralType",
+    "value": "2021-08-01"
+  },
+  {
+    "$type": "ObjectType",
+    "name": "Microsoft.Network/firewallPolicies/ruleCollectionGroups",
+    "properties": {
+      "id": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 10,
+        "description": "The resource id"
+      },
+      "name": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 9,
+        "description": "The resource name"
+      },
+      "type": {
+        "type": {
+          "$ref": "#/76"
+        },
+        "flags": 10,
+        "description": "The resource type"
+      },
+      "apiVersion": {
+        "type": {
+          "$ref": "#/77"
+        },
+        "flags": 10,
+        "description": "The resource api version"
+      },
+      "properties": {
+        "type": {
+          "$ref": "#/79"
+        },
+        "flags": 0,
+        "description": "The properties of the firewall policy rule collection group."
+      },
+      "etag": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 2,
+        "description": "A unique read-only string that changes whenever the resource is updated."
+      }
+    }
+  },
+  {
+    "$type": "ObjectType",
+    "name": "FirewallPolicyRuleCollectionGroupProperties",
+    "properties": {
+      "priority": {
+        "type": {
+          "$ref": "#/80"
+        },
+        "flags": 0,
+        "description": "Priority of the Firewall Policy Rule Collection Group resource."
+      },
+      "ruleCollections": {
+        "type": {
+          "$ref": "#/136"
+        },
+        "flags": 0,
+        "description": "Group of Firewall Policy rule collections."
+      },
+      "provisioningState": {
+        "type": {
+          "$ref": "#/141"
+        },
+        "flags": 2,
+        "description": "The provisioning state of the firewall policy rule collection group resource."
+      }
+    }
+  },
+  {
+    "$type": "IntegerType",
+    "minValue": 100,
+    "maxValue": 65000
+  },
+  {
+    "$type": "DiscriminatedObjectType",
+    "name": "FirewallPolicyRuleCollection",
+    "discriminator": "ruleCollectionType",
+    "baseProperties": {
+      "name": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 0,
+        "description": "The name of the rule collection."
+      },
+      "priority": {
+        "type": {
+          "$ref": "#/80"
+        },
+        "flags": 0,
+        "description": "Priority of the Firewall Policy Rule Collection resource."
+      }
+    },
+    "elements": {
+      "FirewallPolicyFilterRuleCollection": {
+        "$ref": "#/82"
+      },
+      "FirewallPolicyNatRuleCollection": {
+        "$ref": "#/130"
+      }
+    }
+  },
+  {
+    "$type": "ObjectType",
+    "name": "FirewallPolicyFilterRuleCollection",
+    "properties": {
+      "action": {
+        "type": {
+          "$ref": "#/83"
+        },
+        "flags": 0,
+        "description": "The action type of a Filter rule collection."
+      },
+      "rules": {
+        "type": {
+          "$ref": "#/128"
+        },
+        "flags": 0,
+        "description": "List of rules included in a rule collection."
+      },
+      "ruleCollectionType": {
+        "type": {
+          "$ref": "#/129"
+        },
+        "flags": 1,
+        "description": "The type of the rule collection."
+      }
+    }
+  },
+  {
+    "$type": "ObjectType",
+    "name": "FirewallPolicyFilterRuleCollectionAction",
+    "properties": {
+      "type": {
+        "type": {
+          "$ref": "#/86"
+        },
+        "flags": 0,
+        "description": "The type of action."
+      }
+    }
+  },
+  {
+    "$type": "StringLiteralType",
+    "value": "Allow"
+  },
+  {
+    "$type": "StringLiteralType",
+    "value": "Deny"
+  },
+  {
+    "$type": "UnionType",
+    "elements": [
+      {
+        "$ref": "#/84"
+      },
+      {
+        "$ref": "#/85"
+      },
+      {
+        "$ref": "#/0"
+      }
+    ]
+  },
+  {
+    "$type": "DiscriminatedObjectType",
+    "name": "FirewallPolicyRule",
+    "discriminator": "ruleType",
+    "baseProperties": {
+      "name": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 0,
+        "description": "Name of the rule."
+      },
+      "description": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 0,
+        "description": "Description of the rule."
+      }
+    },
+    "elements": {
+      "ApplicationRule": {
+        "$ref": "#/88"
+      },
+      "NatRule": {
+        "$ref": "#/102"
+      },
+      "NetworkRule": {
+        "$ref": "#/114"
+      }
+    }
+  },
+  {
+    "$type": "ObjectType",
+    "name": "ApplicationRule",
+    "properties": {
+      "sourceAddresses": {
+        "type": {
+          "$ref": "#/89"
+        },
+        "flags": 0,
+        "description": "List of source IP addresses for this rule."
+      },
+      "destinationAddresses": {
+        "type": {
+          "$ref": "#/90"
+        },
+        "flags": 0,
+        "description": "List of destination IP addresses or Service Tags."
+      },
+      "protocols": {
+        "type": {
+          "$ref": "#/95"
+        },
+        "flags": 0,
+        "description": "Array of Application Protocols."
+      },
+      "targetFqdns": {
+        "type": {
+          "$ref": "#/96"
+        },
+        "flags": 0,
+        "description": "List of FQDNs for this rule."
+      },
+      "targetUrls": {
+        "type": {
+          "$ref": "#/97"
+        },
+        "flags": 0,
+        "description": "List of Urls for this rule condition."
+      },
+      "fqdnTags": {
+        "type": {
+          "$ref": "#/98"
+        },
+        "flags": 0,
+        "description": "List of FQDN Tags for this rule."
+      },
+      "sourceIpGroups": {
+        "type": {
+          "$ref": "#/99"
+        },
+        "flags": 0,
+        "description": "List of source IpGroups for this rule."
+      },
+      "terminateTLS": {
+        "type": {
+          "$ref": "#/22"
+        },
+        "flags": 0,
+        "description": "Terminate TLS connections for this rule."
+      },
+      "webCategories": {
+        "type": {
+          "$ref": "#/100"
+        },
+        "flags": 0,
+        "description": "List of destination azure web categories."
+      },
+      "ruleType": {
+        "type": {
+          "$ref": "#/101"
+        },
+        "flags": 1,
+        "description": "Rule Type."
+      }
+    }
+  },
+  {
+    "$type": "ArrayType",
+    "itemType": {
+      "$ref": "#/0"
+    }
+  },
+  {
+    "$type": "ArrayType",
+    "itemType": {
+      "$ref": "#/0"
+    }
+  },
+  {
+    "$type": "ObjectType",
+    "name": "FirewallPolicyRuleApplicationProtocol",
+    "properties": {
+      "protocolType": {
+        "type": {
+          "$ref": "#/94"
+        },
+        "flags": 0,
+        "description": "Protocol type."
+      },
+      "port": {
+        "type": {
+          "$ref": "#/33"
+        },
+        "flags": 0,
+        "description": "Port number for the protocol, cannot be greater than 64000."
+      }
+    }
+  },
+  {
+    "$type": "StringLiteralType",
+    "value": "Http"
+  },
+  {
+    "$type": "StringLiteralType",
+    "value": "Https"
+  },
+  {
+    "$type": "UnionType",
+    "elements": [
+      {
+        "$ref": "#/92"
+      },
+      {
+        "$ref": "#/93"
+      },
+      {
+        "$ref": "#/0"
+      }
+    ]
+  },
+  {
+    "$type": "ArrayType",
+    "itemType": {
+      "$ref": "#/91"
+    }
+  },
+  {
+    "$type": "ArrayType",
+    "itemType": {
+      "$ref": "#/0"
+    }
+  },
+  {
+    "$type": "ArrayType",
+    "itemType": {
+      "$ref": "#/0"
+    }
+  },
+  {
+    "$type": "ArrayType",
+    "itemType": {
+      "$ref": "#/0"
+    }
+  },
+  {
+    "$type": "ArrayType",
+    "itemType": {
+      "$ref": "#/0"
+    }
+  },
+  {
+    "$type": "ArrayType",
+    "itemType": {
+      "$ref": "#/0"
+    }
+  },
+  {
+    "$type": "StringLiteralType",
+    "value": "ApplicationRule"
+  },
+  {
+    "$type": "ObjectType",
+    "name": "NatRule",
+    "properties": {
+      "ipProtocols": {
+        "type": {
+          "$ref": "#/108"
+        },
+        "flags": 0,
+        "description": "Array of FirewallPolicyRuleNetworkProtocols."
+      },
+      "sourceAddresses": {
+        "type": {
+          "$ref": "#/109"
+        },
+        "flags": 0,
+        "description": "List of source IP addresses for this rule."
+      },
+      "destinationAddresses": {
+        "type": {
+          "$ref": "#/110"
+        },
+        "flags": 0,
+        "description": "List of destination IP addresses or Service Tags."
+      },
+      "destinationPorts": {
+        "type": {
+          "$ref": "#/111"
+        },
+        "flags": 0,
+        "description": "List of destination ports."
+      },
+      "translatedAddress": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 0,
+        "description": "The translated address for this NAT rule."
+      },
+      "translatedPort": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 0,
+        "description": "The translated port for this NAT rule."
+      },
+      "sourceIpGroups": {
+        "type": {
+          "$ref": "#/112"
+        },
+        "flags": 0,
+        "description": "List of source IpGroups for this rule."
+      },
+      "translatedFqdn": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 0,
+        "description": "The translated FQDN for this NAT rule."
+      },
+      "ruleType": {
+        "type": {
+          "$ref": "#/113"
+        },
+        "flags": 1,
+        "description": "Rule Type."
+      }
+    }
+  },
+  {
+    "$type": "StringLiteralType",
+    "value": "TCP"
+  },
+  {
+    "$type": "StringLiteralType",
+    "value": "UDP"
+  },
+  {
+    "$type": "StringLiteralType",
+    "value": "Any"
+  },
+  {
+    "$type": "StringLiteralType",
+    "value": "ICMP"
+  },
+  {
+    "$type": "UnionType",
+    "elements": [
+      {
+        "$ref": "#/103"
+      },
+      {
+        "$ref": "#/104"
+      },
+      {
+        "$ref": "#/105"
+      },
+      {
+        "$ref": "#/106"
+      },
+      {
+        "$ref": "#/0"
+      }
+    ]
+  },
+  {
+    "$type": "ArrayType",
+    "itemType": {
+      "$ref": "#/107"
+    }
+  },
+  {
+    "$type": "ArrayType",
+    "itemType": {
+      "$ref": "#/0"
+    }
+  },
+  {
+    "$type": "ArrayType",
+    "itemType": {
+      "$ref": "#/0"
+    }
+  },
+  {
+    "$type": "ArrayType",
+    "itemType": {
+      "$ref": "#/0"
+    }
+  },
+  {
+    "$type": "ArrayType",
+    "itemType": {
+      "$ref": "#/0"
+    }
+  },
+  {
+    "$type": "StringLiteralType",
+    "value": "NatRule"
+  },
+  {
+    "$type": "ObjectType",
+    "name": "NetworkRule",
+    "properties": {
+      "ipProtocols": {
+        "type": {
+          "$ref": "#/120"
+        },
+        "flags": 0,
+        "description": "Array of FirewallPolicyRuleNetworkProtocols."
+      },
+      "sourceAddresses": {
+        "type": {
+          "$ref": "#/121"
+        },
+        "flags": 0,
+        "description": "List of source IP addresses for this rule."
+      },
+      "destinationAddresses": {
+        "type": {
+          "$ref": "#/122"
+        },
+        "flags": 0,
+        "description": "List of destination IP addresses or Service Tags."
+      },
+      "destinationPorts": {
+        "type": {
+          "$ref": "#/123"
+        },
+        "flags": 0,
+        "description": "List of destination ports."
+      },
+      "sourceIpGroups": {
+        "type": {
+          "$ref": "#/124"
+        },
+        "flags": 0,
+        "description": "List of source IpGroups for this rule."
+      },
+      "destinationIpGroups": {
+        "type": {
+          "$ref": "#/125"
+        },
+        "flags": 0,
+        "description": "List of destination IpGroups for this rule."
+      },
+      "destinationFqdns": {
+        "type": {
+          "$ref": "#/126"
+        },
+        "flags": 0,
+        "description": "List of destination FQDNs."
+      },
+      "ruleType": {
+        "type": {
+          "$ref": "#/127"
+        },
+        "flags": 1,
+        "description": "Rule Type."
+      }
+    }
+  },
+  {
+    "$type": "StringLiteralType",
+    "value": "TCP"
+  },
+  {
+    "$type": "StringLiteralType",
+    "value": "UDP"
+  },
+  {
+    "$type": "StringLiteralType",
+    "value": "Any"
+  },
+  {
+    "$type": "StringLiteralType",
+    "value": "ICMP"
+  },
+  {
+    "$type": "UnionType",
+    "elements": [
+      {
+        "$ref": "#/115"
+      },
+      {
+        "$ref": "#/116"
+      },
+      {
+        "$ref": "#/117"
+      },
+      {
+        "$ref": "#/118"
+      },
+      {
+        "$ref": "#/0"
+      }
+    ]
+  },
+  {
+    "$type": "ArrayType",
+    "itemType": {
+      "$ref": "#/119"
+    }
+  },
+  {
+    "$type": "ArrayType",
+    "itemType": {
+      "$ref": "#/0"
+    }
+  },
+  {
+    "$type": "ArrayType",
+    "itemType": {
+      "$ref": "#/0"
+    }
+  },
+  {
+    "$type": "ArrayType",
+    "itemType": {
+      "$ref": "#/0"
+    }
+  },
+  {
+    "$type": "ArrayType",
+    "itemType": {
+      "$ref": "#/0"
+    }
+  },
+  {
+    "$type": "ArrayType",
+    "itemType": {
+      "$ref": "#/0"
+    }
+  },
+  {
+    "$type": "ArrayType",
+    "itemType": {
+      "$ref": "#/0"
+    }
+  },
+  {
+    "$type": "StringLiteralType",
+    "value": "NetworkRule"
+  },
+  {
+    "$type": "ArrayType",
+    "itemType": {
+      "$ref": "#/87"
+    }
+  },
+  {
+    "$type": "StringLiteralType",
+    "value": "FirewallPolicyFilterRuleCollection"
+  },
+  {
+    "$type": "ObjectType",
+    "name": "FirewallPolicyNatRuleCollection",
+    "properties": {
+      "action": {
+        "type": {
+          "$ref": "#/131"
+        },
+        "flags": 0,
+        "description": "The action type of a Nat rule collection."
+      },
+      "rules": {
+        "type": {
+          "$ref": "#/134"
+        },
+        "flags": 0,
+        "description": "List of rules included in a rule collection."
+      },
+      "ruleCollectionType": {
+        "type": {
+          "$ref": "#/135"
+        },
+        "flags": 1,
+        "description": "The type of the rule collection."
+      }
+    }
+  },
+  {
+    "$type": "ObjectType",
+    "name": "FirewallPolicyNatRuleCollectionAction",
+    "properties": {
+      "type": {
+        "type": {
+          "$ref": "#/133"
+        },
+        "flags": 0,
+        "description": "The type of action."
+      }
+    }
+  },
+  {
+    "$type": "StringLiteralType",
+    "value": "DNAT"
+  },
+  {
+    "$type": "UnionType",
+    "elements": [
+      {
+        "$ref": "#/132"
+      },
+      {
+        "$ref": "#/0"
+      }
+    ]
+  },
+  {
+    "$type": "ArrayType",
+    "itemType": {
+      "$ref": "#/87"
+    }
+  },
+  {
+    "$type": "StringLiteralType",
+    "value": "FirewallPolicyNatRuleCollection"
+  },
+  {
+    "$type": "ArrayType",
+    "itemType": {
+      "$ref": "#/81"
+    }
+  },
+  {
+    "$type": "StringLiteralType",
+    "value": "Succeeded"
+  },
+  {
+    "$type": "StringLiteralType",
+    "value": "Updating"
+  },
+  {
+    "$type": "StringLiteralType",
+    "value": "Deleting"
+  },
+  {
+    "$type": "StringLiteralType",
+    "value": "Failed"
+  },
+  {
+    "$type": "UnionType",
+    "elements": [
+      {
+        "$ref": "#/137"
+      },
+      {
+        "$ref": "#/138"
+      },
+      {
+        "$ref": "#/139"
+      },
+      {
+        "$ref": "#/140"
+      },
+      {
+        "$ref": "#/0"
+      }
+    ]
+  },
+  {
+    "$type": "ResourceType",
+    "name": "Microsoft.Network/firewallPolicies/ruleCollectionGroups@2021-08-01",
+    "scopeType": 8,
+    "body": {
+      "$ref": "#/78"
+    },
+    "flags": 0
+  },
+  {
+    "$type": "StringLiteralType",
+    "value": "default"
+  },
+  {
+    "$type": "StringLiteralType",
+    "value": "Microsoft.Network/firewallPolicies/signatureOverrides"
+  },
+  {
+    "$type": "StringLiteralType",
+    "value": "2021-08-01"
+  },
+  {
+    "$type": "ObjectType",
+    "name": "Microsoft.Network/firewallPolicies/signatureOverrides",
+    "properties": {
+      "id": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 10,
+        "description": "The resource id"
+      },
+      "name": {
+        "type": {
+          "$ref": "#/143"
+        },
+        "flags": 9,
+        "description": "The resource name"
+      },
+      "type": {
+        "type": {
+          "$ref": "#/144"
+        },
+        "flags": 10,
+        "description": "The resource type"
+      },
+      "apiVersion": {
+        "type": {
+          "$ref": "#/145"
+        },
+        "flags": 10,
+        "description": "The resource api version"
+      },
+      "properties": {
+        "type": {
+          "$ref": "#/147"
+        },
+        "flags": 0,
+        "description": "Will contain the properties of the resource (the actual signature overrides)"
+      }
+    }
+  },
+  {
+    "$type": "ObjectType",
+    "name": "SignaturesOverridesProperties",
+    "properties": {
+      "signatures": {
+        "type": {
+          "$ref": "#/148"
+        },
+        "flags": 0,
+        "description": "Dictionary of <string>"
+      }
+    }
+  },
+  {
+    "$type": "ObjectType",
+    "name": "Signatures",
+    "properties": {},
+    "additionalProperties": {
+      "$ref": "#/0"
+    }
+  },
+  {
+    "$type": "ResourceType",
+    "name": "Microsoft.Network/firewallPolicies/signatureOverrides@2021-08-01",
+    "scopeType": 8,
+    "body": {
+      "$ref": "#/146"
+    },
+    "flags": 0
+  },
+  {
+    "$type": "ObjectType",
+    "name": "IdpsQueryObject",
+    "properties": {
+      "filters": {
+        "type": {
+          "$ref": "#/153"
+        },
+        "flags": 0,
+        "description": "Contain all filters names and values"
+      },
+      "search": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 0,
+        "description": "Search term in all columns"
+      },
+      "orderBy": {
+        "type": {
+          "$ref": "#/154"
+        },
+        "flags": 0,
+        "description": "Column to sort response by"
+      },
+      "resultsPerPage": {
+        "type": {
+          "$ref": "#/158"
+        },
+        "flags": 0,
+        "description": "The number of the results to return in each page"
+      },
+      "skip": {
+        "type": {
+          "$ref": "#/23"
+        },
+        "flags": 0,
+        "description": "The number of records matching the filter to skip"
+      }
+    }
+  },
+  {
+    "$type": "ObjectType",
+    "name": "FilterItems",
+    "properties": {
+      "field": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 0,
+        "description": "The name of the field we would like to filter"
+      },
+      "values": {
+        "type": {
+          "$ref": "#/152"
+        },
+        "flags": 0,
+        "description": "List of values to filter the current field by"
+      }
+    }
+  },
+  {
+    "$type": "ArrayType",
+    "itemType": {
+      "$ref": "#/0"
+    }
+  },
+  {
+    "$type": "ArrayType",
+    "itemType": {
+      "$ref": "#/151"
+    }
+  },
+  {
+    "$type": "ObjectType",
+    "name": "OrderBy",
+    "properties": {
+      "field": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 0,
+        "description": "Describes the actual column name to sort by"
+      },
+      "order": {
+        "type": {
+          "$ref": "#/157"
+        },
+        "flags": 0,
+        "description": "Describes if results should be in ascending/descending order"
+      }
+    }
+  },
+  {
+    "$type": "StringLiteralType",
+    "value": "Ascending"
+  },
+  {
+    "$type": "StringLiteralType",
+    "value": "Descending"
+  },
+  {
+    "$type": "UnionType",
+    "elements": [
+      {
+        "$ref": "#/155"
+      },
+      {
+        "$ref": "#/156"
+      },
+      {
+        "$ref": "#/0"
+      }
+    ]
+  },
+  {
+    "$type": "IntegerType",
+    "minValue": 1,
+    "maxValue": 1000
+  },
+  {
+    "$type": "ObjectType",
+    "name": "QueryResults",
+    "properties": {
+      "matchingRecordsCount": {
+        "type": {
+          "$ref": "#/23"
+        },
+        "flags": 0,
+        "description": "Number of total records matching the query."
+      },
+      "signatures": {
+        "type": {
+          "$ref": "#/163"
+        },
+        "flags": 0,
+        "description": "Array containing the results of the query"
+      }
+    }
+  },
+  {
+    "$type": "ObjectType",
+    "name": "SingleQueryResult",
+    "properties": {
+      "signatureId": {
+        "type": {
+          "$ref": "#/23"
+        },
+        "flags": 0,
+        "description": "The ID of the signature"
+      },
+      "mode": {
+        "type": {
+          "$ref": "#/23"
+        },
+        "flags": 0,
+        "description": "The current mode enforced, 0 - Disabled, 1 - Alert, 2 -Deny"
+      },
+      "severity": {
+        "type": {
+          "$ref": "#/23"
+        },
+        "flags": 0,
+        "description": "Describes the severity of signature: 1 - Low, 2 - Medium, 3 - High"
+      },
+      "direction": {
+        "type": {
+          "$ref": "#/23"
+        },
+        "flags": 0,
+        "description": "Describes in which direction signature is being enforced: 0 - Inbound, 1 - OutBound, 2 - Bidirectional"
+      },
+      "group": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 0,
+        "description": "Describes the groups the signature belongs to"
+      },
+      "description": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 0,
+        "description": "Describes what is the signature enforces"
+      },
+      "protocol": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 0,
+        "description": "Describes the protocol the signatures is being enforced in"
+      },
+      "sourcePorts": {
+        "type": {
+          "$ref": "#/161"
+        },
+        "flags": 0,
+        "description": "Describes the list of source ports related to this signature"
+      },
+      "destinationPorts": {
+        "type": {
+          "$ref": "#/162"
+        },
+        "flags": 0,
+        "description": "Describes the list of destination ports related to this signature"
+      },
+      "lastUpdated": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 0,
+        "description": "Describes the last updated time of the signature (provided from 3rd party vendor)"
+      },
+      "inheritedFromParentPolicy": {
+        "type": {
+          "$ref": "#/22"
+        },
+        "flags": 0,
+        "description": "Describes if this override is inherited from base policy or not"
+      }
+    }
+  },
+  {
+    "$type": "ArrayType",
+    "itemType": {
+      "$ref": "#/0"
+    }
+  },
+  {
+    "$type": "ArrayType",
+    "itemType": {
+      "$ref": "#/0"
+    }
+  },
+  {
+    "$type": "ArrayType",
+    "itemType": {
+      "$ref": "#/160"
+    }
+  },
+  {
+    "$type": "ResourceFunctionType",
+    "name": "listIdpsSignatures",
+    "resourceType": "Microsoft.Network/firewallPolicies",
+    "apiVersion": "2021-08-01",
+    "output": {
+      "$ref": "#/159"
+    },
+    "input": {
+      "$ref": "#/150"
+    }
+  },
+  {
+    "$type": "ObjectType",
+    "name": "SignatureOverridesFilterValuesQuery",
+    "properties": {
+      "filterName": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 0,
+        "description": "Describes the name of the column which values will be returned"
+      }
+    }
+  },
+  {
+    "$type": "ObjectType",
+    "name": "SignatureOverridesFilterValuesResponse",
+    "properties": {
+      "filterValues": {
+        "type": {
+          "$ref": "#/167"
+        },
+        "flags": 0,
+        "description": "Describes the possible values"
+      }
+    }
+  },
+  {
+    "$type": "ArrayType",
+    "itemType": {
+      "$ref": "#/0"
+    }
+  },
+  {
+    "$type": "ResourceFunctionType",
+    "name": "listIdpsFilterOptions",
+    "resourceType": "Microsoft.Network/firewallPolicies",
+    "apiVersion": "2021-08-01",
+    "output": {
+      "$ref": "#/166"
+    },
+    "input": {
+      "$ref": "#/165"
+    }
+  }
+]

--- a/src/autorest.bicep/test/integration/generated/bicep/firewalls/microsoft.network/2021-08-01/types.md
+++ b/src/autorest.bicep/test/integration/generated/bicep/firewalls/microsoft.network/2021-08-01/types.md
@@ -1,0 +1,310 @@
+# Microsoft.Network @ 2021-08-01
+
+## Resource Microsoft.Network/firewallPolicies@2021-08-01
+* **Valid Scope(s)**: ResourceGroup
+### Properties
+* **apiVersion**: '2021-08-01' (ReadOnly, DeployTimeConstant): The resource api version
+* **etag**: string (ReadOnly): A unique read-only string that changes whenever the resource is updated.
+* **id**: string (ReadOnly, DeployTimeConstant): The resource id
+* **identity**: [ManagedServiceIdentity](#managedserviceidentity): The identity of the firewall policy.
+* **location**: string: Resource location.
+* **name**: string (Required, DeployTimeConstant): The resource name
+* **properties**: [FirewallPolicyPropertiesFormat](#firewallpolicypropertiesformat): Properties of the firewall policy.
+* **tags**: [ResourceTags](#resourcetags): Resource tags.
+* **type**: 'Microsoft.Network/firewallPolicies' (ReadOnly, DeployTimeConstant): The resource type
+
+## Resource Microsoft.Network/firewallPolicies/ruleCollectionGroups@2021-08-01
+* **Valid Scope(s)**: ResourceGroup
+### Properties
+* **apiVersion**: '2021-08-01' (ReadOnly, DeployTimeConstant): The resource api version
+* **etag**: string (ReadOnly): A unique read-only string that changes whenever the resource is updated.
+* **id**: string (ReadOnly, DeployTimeConstant): The resource id
+* **name**: string (Required, DeployTimeConstant): The resource name
+* **properties**: [FirewallPolicyRuleCollectionGroupProperties](#firewallpolicyrulecollectiongroupproperties): The properties of the firewall policy rule collection group.
+* **type**: 'Microsoft.Network/firewallPolicies/ruleCollectionGroups' (ReadOnly, DeployTimeConstant): The resource type
+
+## Resource Microsoft.Network/firewallPolicies/signatureOverrides@2021-08-01
+* **Valid Scope(s)**: ResourceGroup
+### Properties
+* **apiVersion**: '2021-08-01' (ReadOnly, DeployTimeConstant): The resource api version
+* **id**: string (ReadOnly, DeployTimeConstant): The resource id
+* **name**: 'default' (Required, DeployTimeConstant): The resource name
+* **properties**: [SignaturesOverridesProperties](#signaturesoverridesproperties): Will contain the properties of the resource (the actual signature overrides)
+* **type**: 'Microsoft.Network/firewallPolicies/signatureOverrides' (ReadOnly, DeployTimeConstant): The resource type
+
+## Function listIdpsFilterOptions (Microsoft.Network/firewallPolicies@2021-08-01)
+* **Resource**: Microsoft.Network/firewallPolicies
+* **ApiVersion**: 2021-08-01
+* **Input**: [SignatureOverridesFilterValuesQuery](#signatureoverridesfiltervaluesquery)
+* **Output**: [SignatureOverridesFilterValuesResponse](#signatureoverridesfiltervaluesresponse)
+
+## Function listIdpsSignatures (Microsoft.Network/firewallPolicies@2021-08-01)
+* **Resource**: Microsoft.Network/firewallPolicies
+* **ApiVersion**: 2021-08-01
+* **Input**: [IdpsQueryObject](#idpsqueryobject)
+* **Output**: [QueryResults](#queryresults)
+
+## Components1Jq1T4ISchemasManagedserviceidentityPropertiesUserassignedidentitiesAdditionalproperties
+### Properties
+* **clientId**: string (ReadOnly): The client id of user assigned identity.
+* **principalId**: string (ReadOnly): The principal id of user assigned identity.
+
+## DnsSettings
+### Properties
+* **enableProxy**: bool: Enable DNS Proxy on Firewalls attached to the Firewall Policy.
+* **requireProxyForNetworkRules**: bool: FQDNs in Network Rules are supported when set to true.
+* **servers**: string[]: List of Custom DNS Servers.
+
+## ExplicitProxySettings
+### Properties
+* **enableExplicitProxy**: bool: When set to true, explicit proxy mode is enabled.
+* **httpPort**: int {minValue: 0, maxValue: 64000}: Port number for explicit proxy http protocol, cannot be greater than 64000.
+* **httpsPort**: int {minValue: 0, maxValue: 64000}: Port number for explicit proxy https protocol, cannot be greater than 64000.
+* **pacFile**: string: SAS URL for PAC file.
+* **pacFilePort**: int {minValue: 0, maxValue: 64000}: Port number for firewall to serve PAC file.
+
+## FilterItems
+### Properties
+* **field**: string: The name of the field we would like to filter
+* **values**: string[]: List of values to filter the current field by
+
+## FirewallPolicyCertificateAuthority
+### Properties
+* **keyVaultSecretId**: string: Secret Id of (base-64 encoded unencrypted pfx) 'Secret' or 'Certificate' object stored in KeyVault.
+* **name**: string: Name of the CA certificate.
+
+## FirewallPolicyFilterRuleCollectionAction
+### Properties
+* **type**: 'Allow' | 'Deny' | string: The type of action.
+
+## FirewallPolicyInsights
+### Properties
+* **isEnabled**: bool: A flag to indicate if the insights are enabled on the policy.
+* **logAnalyticsResources**: [FirewallPolicyLogAnalyticsResources](#firewallpolicyloganalyticsresources): Workspaces needed to configure the Firewall Policy Insights.
+* **retentionDays**: int: Number of days the insights should be enabled on the policy.
+
+## FirewallPolicyIntrusionDetection
+### Properties
+* **configuration**: [FirewallPolicyIntrusionDetectionConfiguration](#firewallpolicyintrusiondetectionconfiguration): Intrusion detection configuration properties.
+* **mode**: 'Alert' | 'Deny' | 'Off' | string: Intrusion detection general state.
+
+## FirewallPolicyIntrusionDetectionBypassTrafficSpecifications
+### Properties
+* **description**: string: Description of the bypass traffic rule.
+* **destinationAddresses**: string[]: List of destination IP addresses or ranges for this rule.
+* **destinationIpGroups**: string[]: List of destination IpGroups for this rule.
+* **destinationPorts**: string[]: List of destination ports or ranges.
+* **name**: string: Name of the bypass traffic rule.
+* **protocol**: 'ANY' | 'ICMP' | 'TCP' | 'UDP' | string: The rule bypass protocol.
+* **sourceAddresses**: string[]: List of source IP addresses or ranges for this rule.
+* **sourceIpGroups**: string[]: List of source IpGroups for this rule.
+
+## FirewallPolicyIntrusionDetectionConfiguration
+### Properties
+* **bypassTrafficSettings**: [FirewallPolicyIntrusionDetectionBypassTrafficSpecifications](#firewallpolicyintrusiondetectionbypasstrafficspecifications)[]: List of rules for traffic to bypass.
+* **privateRanges**: string[]: IDPS Private IP address ranges are used to identify traffic direction (i.e. inbound, outbound, etc.). By default, only ranges defined by IANA RFC 1918 are considered private IP addresses. To modify default ranges, specify your Private IP address ranges with this property
+* **signatureOverrides**: [FirewallPolicyIntrusionDetectionSignatureSpecification](#firewallpolicyintrusiondetectionsignaturespecification)[]: List of specific signatures states.
+
+## FirewallPolicyIntrusionDetectionSignatureSpecification
+### Properties
+* **id**: string: Signature id.
+* **mode**: 'Alert' | 'Deny' | 'Off' | string: The signature state.
+
+## FirewallPolicyLogAnalyticsResources
+### Properties
+* **defaultWorkspaceId**: [SubResource](#subresource): The default workspace Id for Firewall Policy Insights.
+* **workspaces**: [FirewallPolicyLogAnalyticsWorkspace](#firewallpolicyloganalyticsworkspace)[]: List of workspaces for Firewall Policy Insights.
+
+## FirewallPolicyLogAnalyticsWorkspace
+### Properties
+* **region**: string: Region to configure the Workspace.
+* **workspaceId**: [SubResource](#subresource): The workspace Id for Firewall Policy Insights.
+
+## FirewallPolicyNatRuleCollectionAction
+### Properties
+* **type**: 'DNAT' | string: The type of action.
+
+## FirewallPolicyPropertiesFormat
+### Properties
+* **basePolicy**: [SubResource](#subresource): The parent firewall policy from which rules are inherited.
+* **childPolicies**: [SubResource](#subresource)[] (ReadOnly): List of references to Child Firewall Policies.
+* **dnsSettings**: [DnsSettings](#dnssettings): DNS Proxy Settings definition.
+* **explicitProxySettings**: [ExplicitProxySettings](#explicitproxysettings): Explicit Proxy Settings definition.
+* **firewalls**: [SubResource](#subresource)[] (ReadOnly): List of references to Azure Firewalls that this Firewall Policy is associated with.
+* **insights**: [FirewallPolicyInsights](#firewallpolicyinsights): Insights on Firewall Policy.
+* **intrusionDetection**: [FirewallPolicyIntrusionDetection](#firewallpolicyintrusiondetection): The configuration for Intrusion detection.
+* **provisioningState**: 'Deleting' | 'Failed' | 'Succeeded' | 'Updating' | string (ReadOnly): The provisioning state of the firewall policy resource.
+* **ruleCollectionGroups**: [SubResource](#subresource)[] (ReadOnly): List of references to FirewallPolicyRuleCollectionGroups.
+* **sku**: [FirewallPolicySku](#firewallpolicysku): The Firewall Policy SKU.
+* **snat**: [FirewallPolicySnat](#firewallpolicysnat): The private IP addresses/IP ranges to which traffic will not be SNAT.
+* **sql**: [FirewallPolicySQL](#firewallpolicysql): SQL Settings definition.
+* **threatIntelMode**: 'Alert' | 'Deny' | 'Off' | string: The operation mode for Threat Intelligence.
+* **threatIntelWhitelist**: [FirewallPolicyThreatIntelWhitelist](#firewallpolicythreatintelwhitelist): ThreatIntel Whitelist for Firewall Policy.
+* **transportSecurity**: [FirewallPolicyTransportSecurity](#firewallpolicytransportsecurity): TLS Configuration definition.
+
+## FirewallPolicyRule
+* **Discriminator**: ruleType
+
+### Base Properties
+* **description**: string: Description of the rule.
+* **name**: string: Name of the rule.
+
+### ApplicationRule
+#### Properties
+* **destinationAddresses**: string[]: List of destination IP addresses or Service Tags.
+* **fqdnTags**: string[]: List of FQDN Tags for this rule.
+* **protocols**: [FirewallPolicyRuleApplicationProtocol](#firewallpolicyruleapplicationprotocol)[]: Array of Application Protocols.
+* **ruleType**: 'ApplicationRule' (Required): Rule Type.
+* **sourceAddresses**: string[]: List of source IP addresses for this rule.
+* **sourceIpGroups**: string[]: List of source IpGroups for this rule.
+* **targetFqdns**: string[]: List of FQDNs for this rule.
+* **targetUrls**: string[]: List of Urls for this rule condition.
+* **terminateTLS**: bool: Terminate TLS connections for this rule.
+* **webCategories**: string[]: List of destination azure web categories.
+
+### NatRule
+#### Properties
+* **destinationAddresses**: string[]: List of destination IP addresses or Service Tags.
+* **destinationPorts**: string[]: List of destination ports.
+* **ipProtocols**: ('Any' | 'ICMP' | 'TCP' | 'UDP' | string)[]: Array of FirewallPolicyRuleNetworkProtocols.
+* **ruleType**: 'NatRule' (Required): Rule Type.
+* **sourceAddresses**: string[]: List of source IP addresses for this rule.
+* **sourceIpGroups**: string[]: List of source IpGroups for this rule.
+* **translatedAddress**: string: The translated address for this NAT rule.
+* **translatedFqdn**: string: The translated FQDN for this NAT rule.
+* **translatedPort**: string: The translated port for this NAT rule.
+
+### NetworkRule
+#### Properties
+* **destinationAddresses**: string[]: List of destination IP addresses or Service Tags.
+* **destinationFqdns**: string[]: List of destination FQDNs.
+* **destinationIpGroups**: string[]: List of destination IpGroups for this rule.
+* **destinationPorts**: string[]: List of destination ports.
+* **ipProtocols**: ('Any' | 'ICMP' | 'TCP' | 'UDP' | string)[]: Array of FirewallPolicyRuleNetworkProtocols.
+* **ruleType**: 'NetworkRule' (Required): Rule Type.
+* **sourceAddresses**: string[]: List of source IP addresses for this rule.
+* **sourceIpGroups**: string[]: List of source IpGroups for this rule.
+
+
+## FirewallPolicyRuleApplicationProtocol
+### Properties
+* **port**: int {minValue: 0, maxValue: 64000}: Port number for the protocol, cannot be greater than 64000.
+* **protocolType**: 'Http' | 'Https' | string: Protocol type.
+
+## FirewallPolicyRuleCollection
+* **Discriminator**: ruleCollectionType
+
+### Base Properties
+* **name**: string: The name of the rule collection.
+* **priority**: int {minValue: 100, maxValue: 65000}: Priority of the Firewall Policy Rule Collection resource.
+
+### FirewallPolicyFilterRuleCollection
+#### Properties
+* **action**: [FirewallPolicyFilterRuleCollectionAction](#firewallpolicyfilterrulecollectionaction): The action type of a Filter rule collection.
+* **ruleCollectionType**: 'FirewallPolicyFilterRuleCollection' (Required): The type of the rule collection.
+* **rules**: [FirewallPolicyRule](#firewallpolicyrule)[]: List of rules included in a rule collection.
+
+### FirewallPolicyNatRuleCollection
+#### Properties
+* **action**: [FirewallPolicyNatRuleCollectionAction](#firewallpolicynatrulecollectionaction): The action type of a Nat rule collection.
+* **ruleCollectionType**: 'FirewallPolicyNatRuleCollection' (Required): The type of the rule collection.
+* **rules**: [FirewallPolicyRule](#firewallpolicyrule)[]: List of rules included in a rule collection.
+
+
+## FirewallPolicyRuleCollectionGroupProperties
+### Properties
+* **priority**: int {minValue: 100, maxValue: 65000}: Priority of the Firewall Policy Rule Collection Group resource.
+* **provisioningState**: 'Deleting' | 'Failed' | 'Succeeded' | 'Updating' | string (ReadOnly): The provisioning state of the firewall policy rule collection group resource.
+* **ruleCollections**: [FirewallPolicyRuleCollection](#firewallpolicyrulecollection)[]: Group of Firewall Policy rule collections.
+
+## FirewallPolicySku
+### Properties
+* **tier**: 'Basic' | 'Premium' | 'Standard' | string: Tier of Firewall Policy.
+
+## FirewallPolicySnat
+### Properties
+* **privateRanges**: string[]: List of private IP addresses/IP address ranges to not be SNAT.
+
+## FirewallPolicySQL
+### Properties
+* **allowSqlRedirect**: bool: A flag to indicate if SQL Redirect traffic filtering is enabled. Turning on the flag requires no rule using port 11000-11999.
+
+## FirewallPolicyThreatIntelWhitelist
+### Properties
+* **fqdns**: string[]: List of FQDNs for the ThreatIntel Whitelist.
+* **ipAddresses**: string[]: List of IP addresses for the ThreatIntel Whitelist.
+
+## FirewallPolicyTransportSecurity
+### Properties
+* **certificateAuthority**: [FirewallPolicyCertificateAuthority](#firewallpolicycertificateauthority): The CA used for intermediate CA generation.
+
+## IdpsQueryObject
+### Properties
+* **filters**: [FilterItems](#filteritems)[]: Contain all filters names and values
+* **orderBy**: [OrderBy](#orderby): Column to sort response by
+* **resultsPerPage**: int {minValue: 1, maxValue: 1000}: The number of the results to return in each page
+* **search**: string: Search term in all columns
+* **skip**: int: The number of records matching the filter to skip
+
+## ManagedServiceIdentity
+### Properties
+* **principalId**: string (ReadOnly): The principal id of the system assigned identity. This property will only be provided for a system assigned identity.
+* **tenantId**: string (ReadOnly): The tenant id of the system assigned identity. This property will only be provided for a system assigned identity.
+* **type**: 'None' | 'SystemAssigned' | 'SystemAssigned, UserAssigned' | 'UserAssigned': The type of identity used for the resource. The type 'SystemAssigned, UserAssigned' includes both an implicitly created identity and a set of user assigned identities. The type 'None' will remove any identities from the virtual machine.
+* **userAssignedIdentities**: [ManagedServiceIdentityUserAssignedIdentities](#managedserviceidentityuserassignedidentities): The list of user identities associated with resource. The user identity dictionary key references will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'.
+
+## ManagedServiceIdentityUserAssignedIdentities
+### Properties
+### Additional Properties
+* **Additional Properties Type**: [Components1Jq1T4ISchemasManagedserviceidentityPropertiesUserassignedidentitiesAdditionalproperties](#components1jq1t4ischemasmanagedserviceidentitypropertiesuserassignedidentitiesadditionalproperties)
+
+## OrderBy
+### Properties
+* **field**: string: Describes the actual column name to sort by
+* **order**: 'Ascending' | 'Descending' | string: Describes if results should be in ascending/descending order
+
+## QueryResults
+### Properties
+* **matchingRecordsCount**: int: Number of total records matching the query.
+* **signatures**: [SingleQueryResult](#singlequeryresult)[]: Array containing the results of the query
+
+## ResourceTags
+### Properties
+### Additional Properties
+* **Additional Properties Type**: string
+
+## SignatureOverridesFilterValuesQuery
+### Properties
+* **filterName**: string: Describes the name of the column which values will be returned
+
+## SignatureOverridesFilterValuesResponse
+### Properties
+* **filterValues**: string[]: Describes the possible values
+
+## Signatures
+### Properties
+### Additional Properties
+* **Additional Properties Type**: string
+
+## SignaturesOverridesProperties
+### Properties
+* **signatures**: [Signatures](#signatures): Dictionary of <string>
+
+## SingleQueryResult
+### Properties
+* **description**: string: Describes what is the signature enforces
+* **destinationPorts**: string[]: Describes the list of destination ports related to this signature
+* **direction**: int: Describes in which direction signature is being enforced: 0 - Inbound, 1 - OutBound, 2 - Bidirectional
+* **group**: string: Describes the groups the signature belongs to
+* **inheritedFromParentPolicy**: bool: Describes if this override is inherited from base policy or not
+* **lastUpdated**: string: Describes the last updated time of the signature (provided from 3rd party vendor)
+* **mode**: int: The current mode enforced, 0 - Disabled, 1 - Alert, 2 -Deny
+* **protocol**: string: Describes the protocol the signatures is being enforced in
+* **severity**: int: Describes the severity of signature: 1 - Low, 2 - Medium, 3 - High
+* **signatureId**: int: The ID of the signature
+* **sourcePorts**: string[]: Describes the list of source ports related to this signature
+
+## SubResource
+### Properties
+* **id**: string: Resource ID.
+

--- a/src/autorest.bicep/test/integration/integration.test.ts
+++ b/src/autorest.bicep/test/integration/integration.test.ts
@@ -9,7 +9,8 @@ const outputBaseDir = `${__dirname}/generated`;
 
 // add any new spec paths under ./specs to this list
 const specs = [
-  `basic`
+  `basic`,
+  `firewalls`
 ]
 
 for (const armSchema of [false, true]) {

--- a/src/autorest.bicep/test/integration/specs/basic/resource-manager/Test.Rp1/stable/2021-10-31/spec.json
+++ b/src/autorest.bicep/test/integration/specs/basic/resource-manager/Test.Rp1/stable/2021-10-31/spec.json
@@ -189,8 +189,19 @@
       "maxItems": 10
     },
     "DiscriminatedUnionTestType": {
+      "type": "object",
+      "required": [
+        "properties"
+      ],
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/DiscriminatedUnionTestTypeProperties"
+        }
+      }
+    },
+    "DiscriminatedUnionTestTypeProperties": {
       "allOf": [
-        {"$ref": "#/definitions/DiscriminatedUnionTestTypeAncestor"}
+        {"$ref": "#/definitions/DiscriminatedUnionTestTypePropertiesAncestor"}
       ],
       "type": "object",
       "required": [
@@ -213,7 +224,7 @@
       },
       "discriminator": "type"
     },
-    "DiscriminatedUnionTestTypeAncestor": {
+    "DiscriminatedUnionTestTypePropertiesAncestor": {
       "type": "object",
       "properties": {
         "foo": {
@@ -222,10 +233,10 @@
         }
       }
     },
-    "DiscriminatedUnionTestTypeBranchWithInheritedProps": {
+    "DiscriminatedUnionTestTypePropertiesBranchWithInheritedProps": {
       "allOf": [
-        {"$ref": "#/definitions/DiscriminatedUnionTestType"},
-        {"$ref": "#/definitions/DiscriminatedUnionTestTypeBranchWithInheritedPropsAncestor" }
+        {"$ref": "#/definitions/DiscriminatedUnionTestTypeProperties"},
+        {"$ref": "#/definitions/DiscriminatedUnionTestTypePropertiesBranchWithInheritedPropsAncestor" }
       ],
       "type": "object",
       "properties": {
@@ -236,7 +247,7 @@
       },
       "x-ms-discriminator-value": "inherited"
     },
-    "DiscriminatedUnionTestTypeBranchWithInheritedPropsAncestor": {
+    "DiscriminatedUnionTestTypePropertiesBranchWithInheritedPropsAncestor": {
       "type": "object",
       "properties": {
         "baz": {
@@ -245,9 +256,9 @@
         }
       }
     },
-    "DiscriminatedUnionTestTypeBranchWithAllInlineProps": {
+    "DiscriminatedUnionTestTypePropertiesBranchWithAllInlineProps": {
       "allOf": [
-        {"$ref": "#/definitions/DiscriminatedUnionTestType"}
+        {"$ref": "#/definitions/DiscriminatedUnionTestTypeProperties"}
       ],
       "type": "object",
       "properties": {
@@ -266,9 +277,9 @@
       },
       "x-ms-discriminator-value": "inline"
     },
-    "DiscriminatedUnionTestTypeBranchWithOverride": {
+    "DiscriminatedUnionTestTypePropertiesBranchWithOverride": {
       "allOf": [
-        {"$ref": "#/definitions/DiscriminatedUnionTestType"}
+        {"$ref": "#/definitions/DiscriminatedUnionTestTypeProperties"}
       ],
       "type": "object",
       "properties": {

--- a/src/autorest.bicep/test/integration/specs/firewalls/resource-manager/Microsoft.Network/stable/2021-08-01/azureFirewall.json
+++ b/src/autorest.bicep/test/integration/specs/firewalls/resource-manager/Microsoft.Network/stable/2021-08-01/azureFirewall.json
@@ -1,0 +1,1086 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "NetworkManagementClient",
+    "description": "The Microsoft Azure Network management API provides a RESTful set of web services that interact with Microsoft Azure Networks service to manage your network resources. The API has entities that capture the relationship between an end user and the Microsoft Azure Networks service.",
+    "version": "2021-08-01"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/azureFirewalls/{azureFirewallName}": {
+      "delete": {
+        "tags": [
+          "AzureFirewalls"
+        ],
+        "operationId": "AzureFirewalls_Delete",
+        "description": "Deletes the specified Azure Firewall.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "azureFirewallName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Azure Firewall."
+          },
+          {
+            "$ref": "./network.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "./network.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Accepted and the operation will complete asynchronously."
+          },
+          "204": {
+            "description": "Request successful. Resource with the specified name does not exist."
+          },
+          "200": {
+            "description": "Delete successful."
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "./network.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete Azure Firewall": {
+            "$ref": "./examples/AzureFirewallDelete.json"
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        }
+      },
+      "get": {
+        "tags": [
+          "AzureFirewalls"
+        ],
+        "operationId": "AzureFirewalls_Get",
+        "description": "Gets the specified Azure Firewall.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "azureFirewallName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Azure Firewall."
+          },
+          {
+            "$ref": "./network.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "./network.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns an AzureFirewall resource.",
+            "schema": {
+              "$ref": "#/definitions/AzureFirewall"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "./network.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Azure Firewall": {
+            "$ref": "./examples/AzureFirewallGet.json"
+          },
+          "Get Azure Firewall With Zones": {
+            "$ref": "./examples/AzureFirewallGetWithZones.json"
+          },
+          "Get Azure Firewall With management subnet": {
+            "$ref": "./examples/AzureFirewallGetWithMgmtSubnet.json"
+          },
+          "Get Azure Firewall With Additional Properties": {
+            "$ref": "./examples/AzureFirewallGetWithAdditionalProperties.json"
+          },
+          "Get Azure Firewall With IpGroups": {
+            "$ref": "./examples/AzureFirewallGetWithIpGroups.json"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "AzureFirewalls"
+        ],
+        "operationId": "AzureFirewalls_CreateOrUpdate",
+        "description": "Creates or updates the specified Azure Firewall.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "azureFirewallName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 56,
+            "description": "The name of the Azure Firewall."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AzureFirewall"
+            },
+            "description": "Parameters supplied to the create or update Azure Firewall operation."
+          },
+          {
+            "$ref": "./network.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "./network.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Create successful. The operation returns the resulting AzureFirewall resource.",
+            "schema": {
+              "$ref": "#/definitions/AzureFirewall"
+            }
+          },
+          "200": {
+            "description": "Update successful. The operation returns the resulting AzureFirewall resource.",
+            "schema": {
+              "$ref": "#/definitions/AzureFirewall"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "./network.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create Azure Firewall": {
+            "$ref": "./examples/AzureFirewallPut.json"
+          },
+          "Create Azure Firewall With Zones": {
+            "$ref": "./examples/AzureFirewallPutWithZones.json"
+          },
+          "Create Azure Firewall With management subnet": {
+            "$ref": "./examples/AzureFirewallPutWithMgmtSubnet.json"
+          },
+          "Create Azure Firewall in virtual Hub": {
+            "$ref": "./examples/AzureFirewallPutInHub.json"
+          },
+          "Create Azure Firewall With Additional Properties": {
+            "$ref": "./examples/AzureFirewallPutWithAdditionalProperties.json"
+          },
+          "Create Azure Firewall With IpGroups": {
+            "$ref": "./examples/AzureFirewallPutWithIpGroups.json"
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        }
+      },
+      "patch": {
+        "tags": [
+          "AzureFirewalls"
+        ],
+        "operationId": "AzureFirewalls_UpdateTags",
+        "description": "Updates tags of an Azure Firewall resource.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "azureFirewallName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Azure Firewall."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "./network.json#/definitions/TagsObject"
+            },
+            "description": "Parameters supplied to update azure firewall tags."
+          },
+          {
+            "$ref": "./network.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "./network.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Accepted and the operation will complete asynchronously."
+          },
+          "200": {
+            "description": "Update successful. The operation returns the resulting AzureFirewall resource.",
+            "schema": {
+              "$ref": "#/definitions/AzureFirewall"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "./network.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Update Azure Firewall Tags": {
+            "$ref": "./examples/AzureFirewallUpdateTags.json"
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/azureFirewalls": {
+      "get": {
+        "tags": [
+          "AzureFirewalls"
+        ],
+        "operationId": "AzureFirewalls_List",
+        "description": "Lists all Azure Firewalls in a resource group.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "$ref": "./network.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "./network.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success. The operation returns a list of AzureFirewall resources.",
+            "schema": {
+              "$ref": "#/definitions/AzureFirewallListResult"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "./network.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List all Azure Firewalls for a given resource group": {
+            "$ref": "./examples/AzureFirewallListByResourceGroup.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/azureFirewalls": {
+      "get": {
+        "tags": [
+          "AzureFirewalls"
+        ],
+        "operationId": "AzureFirewalls_ListAll",
+        "description": "Gets all the Azure Firewalls in a subscription.",
+        "parameters": [
+          {
+            "$ref": "./network.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "./network.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success. The operation returns a list of AzureFirewall resources.",
+            "schema": {
+              "$ref": "#/definitions/AzureFirewallListResult"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "./network.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List all Azure Firewalls for a given subscription": {
+            "$ref": "./examples/AzureFirewallListBySubscription.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "AzureFirewallIPConfigurationPropertiesFormat": {
+      "properties": {
+        "privateIPAddress": {
+          "type": "string",
+          "readOnly": true,
+          "description": "The Firewall Internal Load Balancer IP to be used as the next hop in User Defined Routes."
+        },
+        "subnet": {
+          "$ref": "./network.json#/definitions/SubResource",
+          "description": "Reference to the subnet resource. This resource must be named 'AzureFirewallSubnet' or 'AzureFirewallManagementSubnet'."
+        },
+        "publicIPAddress": {
+          "$ref": "./network.json#/definitions/SubResource",
+          "description": "Reference to the PublicIP resource. This field is a mandatory input if subnet is not null."
+        },
+        "provisioningState": {
+          "readOnly": true,
+          "$ref": "./network.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the Azure firewall IP configuration resource."
+        }
+      },
+      "description": "Properties of IP configuration of an Azure Firewall."
+    },
+    "AzureFirewallIPConfiguration": {
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/AzureFirewallIPConfigurationPropertiesFormat",
+          "description": "Properties of the azure firewall IP configuration."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the resource that is unique within a resource group. This name can be used to access the resource."
+        },
+        "etag": {
+          "type": "string",
+          "readOnly": true,
+          "description": "A unique read-only string that changes whenever the resource is updated."
+        },
+        "type": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Type of the resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./network.json#/definitions/SubResource"
+        }
+      ],
+      "description": "IP configuration of an Azure Firewall."
+    },
+    "AzureFirewallPublicIPAddress": {
+      "properties": {
+        "address": {
+          "type": "string",
+          "description": "Public IP Address value."
+        }
+      },
+      "description": "Public IP Address associated with azure firewall."
+    },
+    "AzureFirewallIpGroups": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "readOnly": true,
+          "description": "Resource ID."
+        },
+        "changeNumber": {
+          "type": "string",
+          "readOnly": true,
+          "description": "The iteration number."
+        }
+      },
+      "description": "IpGroups associated with azure firewall."
+    },
+    "HubPublicIPAddresses": {
+      "properties": {
+        "addresses": {
+          "type": "array",
+          "description": "The list of Public IP addresses associated with azure firewall or IP addresses to be retained.",
+          "items": {
+            "$ref": "#/definitions/AzureFirewallPublicIPAddress"
+          }
+        },
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The number of Public IP addresses associated with azure firewall."
+        }
+      },
+      "description": "Public IP addresses associated with azure firewall."
+    },
+    "HubIPAddresses": {
+      "properties": {
+        "publicIPs": {
+          "description": "Public IP addresses associated with azure firewall.",
+          "$ref": "#/definitions/HubPublicIPAddresses"
+        },
+        "privateIPAddress": {
+          "type": "string",
+          "description": "Private IP Address associated with azure firewall."
+        }
+      },
+      "description": "IP addresses associated with azure firewall."
+    },
+    "IpGroups": {
+      "type": "array",
+      "description": "List of IpGroups associated with azure firewall.",
+      "items": {
+        "$ref": "#/definitions/AzureFirewallIpGroups"
+      }
+    },
+    "AzureFirewallPropertiesFormat": {
+      "properties": {
+        "applicationRuleCollections": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AzureFirewallApplicationRuleCollection"
+          },
+          "description": "Collection of application rule collections used by Azure Firewall."
+        },
+        "natRuleCollections": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AzureFirewallNatRuleCollection"
+          },
+          "description": "Collection of NAT rule collections used by Azure Firewall."
+        },
+        "networkRuleCollections": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AzureFirewallNetworkRuleCollection"
+          },
+          "description": "Collection of network rule collections used by Azure Firewall."
+        },
+        "ipConfigurations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AzureFirewallIPConfiguration"
+          },
+          "description": "IP configuration of the Azure Firewall resource."
+        },
+        "managementIpConfiguration": {
+          "$ref": "#/definitions/AzureFirewallIPConfiguration",
+          "description": "IP configuration of the Azure Firewall used for management traffic."
+        },
+        "provisioningState": {
+          "readOnly": true,
+          "$ref": "./network.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the Azure firewall resource."
+        },
+        "threatIntelMode": {
+          "description": "The operation mode for Threat Intelligence.",
+          "$ref": "#/definitions/AzureFirewallThreatIntelMode"
+        },
+        "virtualHub": {
+          "$ref": "./network.json#/definitions/SubResource",
+          "description": "The virtualHub to which the firewall belongs."
+        },
+        "firewallPolicy": {
+          "$ref": "./network.json#/definitions/SubResource",
+          "description": "The firewallPolicy associated with this azure firewall."
+        },
+        "hubIPAddresses": {
+          "description": "IP addresses associated with AzureFirewall.",
+          "$ref": "#/definitions/HubIPAddresses"
+        },
+        "ipGroups": {
+          "readOnly": true,
+          "description": "IpGroups associated with AzureFirewall.",
+          "$ref": "#/definitions/IpGroups"
+        },
+        "sku": {
+          "description": "The Azure Firewall Resource SKU.",
+          "$ref": "#/definitions/AzureFirewallSku"
+        },
+        "additionalProperties": {
+          "$ref": "#/definitions/AzureFirewallAdditionalProperties",
+          "description": "The additional properties used to further config this azure firewall."
+        }
+      },
+      "description": "Properties of the Azure Firewall."
+    },
+    "AzureFirewall": {
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/AzureFirewallPropertiesFormat",
+          "description": "Properties of the azure firewall."
+        },
+        "zones": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "A list of availability zones denoting where the resource needs to come from."
+        },
+        "etag": {
+          "type": "string",
+          "readOnly": true,
+          "description": "A unique read-only string that changes whenever the resource is updated."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./network.json#/definitions/Resource"
+        }
+      ],
+      "description": "Azure Firewall resource."
+    },
+    "AzureFirewallListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AzureFirewall"
+          },
+          "description": "List of Azure Firewalls in a resource group."
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "URL to get the next set of results."
+        }
+      },
+      "description": "Response for ListAzureFirewalls API service call."
+    },
+    "AzureFirewallThreatIntelMode": {
+      "type": "string",
+      "description": "The operation mode for Threat Intel.",
+      "enum": [
+        "Alert",
+        "Deny",
+        "Off"
+      ],
+      "x-ms-enum": {
+        "name": "AzureFirewallThreatIntelMode",
+        "modelAsString": true
+      }
+    },
+    "AzureFirewallAdditionalProperties": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "The additional properties of azure firewall."
+    },
+    "AzureFirewallApplicationRuleCollectionPropertiesFormat": {
+      "properties": {
+        "priority": {
+          "type": "integer",
+          "format": "int32",
+          "maximum": 65000,
+          "exclusiveMaximum": false,
+          "minimum": 100,
+          "exclusiveMinimum": false,
+          "description": "Priority of the application rule collection resource."
+        },
+        "action": {
+          "$ref": "#/definitions/AzureFirewallRCAction",
+          "description": "The action type of a rule collection."
+        },
+        "rules": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AzureFirewallApplicationRule"
+          },
+          "description": "Collection of rules used by a application rule collection."
+        },
+        "provisioningState": {
+          "readOnly": true,
+          "$ref": "./network.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the application rule collection resource."
+        }
+      },
+      "description": "Properties of the application rule collection."
+    },
+    "AzureFirewallApplicationRuleCollection": {
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/AzureFirewallApplicationRuleCollectionPropertiesFormat",
+          "description": "Properties of the azure firewall application rule collection."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the resource that is unique within the Azure firewall. This name can be used to access the resource."
+        },
+        "etag": {
+          "type": "string",
+          "readOnly": true,
+          "description": "A unique read-only string that changes whenever the resource is updated."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./network.json#/definitions/SubResource"
+        }
+      ],
+      "description": "Application rule collection resource."
+    },
+    "AzureFirewallApplicationRuleProtocol": {
+      "properties": {
+        "protocolType": {
+          "description": "Protocol type.",
+          "$ref": "#/definitions/AzureFirewallApplicationRuleProtocolType"
+        },
+        "port": {
+          "type": "integer",
+          "format": "int32",
+          "maximum": 64000,
+          "exclusiveMaximum": false,
+          "minimum": 0,
+          "exclusiveMinimum": false,
+          "description": "Port number for the protocol, cannot be greater than 64000. This field is optional."
+        }
+      },
+      "description": "Properties of the application rule protocol."
+    },
+    "AzureFirewallApplicationRule": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the application rule."
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of the rule."
+        },
+        "sourceAddresses": {
+          "type": "array",
+          "description": "List of source IP addresses for this rule.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "protocols": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AzureFirewallApplicationRuleProtocol"
+          },
+          "description": "Array of ApplicationRuleProtocols."
+        },
+        "targetFqdns": {
+          "type": "array",
+          "description": "List of FQDNs for this rule.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "fqdnTags": {
+          "type": "array",
+          "description": "List of FQDN Tags for this rule.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sourceIpGroups": {
+          "type": "array",
+          "description": "List of source IpGroups for this rule.",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "description": "Properties of an application rule."
+    },
+    "AzureFirewallNatRuleCollectionProperties": {
+      "properties": {
+        "priority": {
+          "type": "integer",
+          "format": "int32",
+          "maximum": 65000,
+          "exclusiveMaximum": false,
+          "minimum": 100,
+          "exclusiveMinimum": false,
+          "description": "Priority of the NAT rule collection resource."
+        },
+        "action": {
+          "$ref": "#/definitions/AzureFirewallNatRCAction",
+          "description": "The action type of a NAT rule collection."
+        },
+        "rules": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AzureFirewallNatRule"
+          },
+          "description": "Collection of rules used by a NAT rule collection."
+        },
+        "provisioningState": {
+          "readOnly": true,
+          "$ref": "./network.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the NAT rule collection resource."
+        }
+      },
+      "description": "Properties of the NAT rule collection."
+    },
+    "AzureFirewallNatRuleCollection": {
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/AzureFirewallNatRuleCollectionProperties",
+          "description": "Properties of the azure firewall NAT rule collection."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the resource that is unique within the Azure firewall. This name can be used to access the resource."
+        },
+        "etag": {
+          "type": "string",
+          "readOnly": true,
+          "description": "A unique read-only string that changes whenever the resource is updated."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./network.json#/definitions/SubResource"
+        }
+      ],
+      "description": "NAT rule collection resource."
+    },
+    "AzureFirewallNatRule": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the NAT rule."
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of the rule."
+        },
+        "sourceAddresses": {
+          "type": "array",
+          "description": "List of source IP addresses for this rule.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "destinationAddresses": {
+          "type": "array",
+          "description": "List of destination IP addresses for this rule. Supports IP ranges, prefixes, and service tags.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "destinationPorts": {
+          "type": "array",
+          "description": "List of destination ports.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "protocols": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AzureFirewallNetworkRuleProtocol"
+          },
+          "description": "Array of AzureFirewallNetworkRuleProtocols applicable to this NAT rule."
+        },
+        "translatedAddress": {
+          "type": "string",
+          "description": "The translated address for this NAT rule."
+        },
+        "translatedPort": {
+          "type": "string",
+          "description": "The translated port for this NAT rule."
+        },
+        "translatedFqdn": {
+          "type": "string",
+          "description": "The translated FQDN for this NAT rule."
+        },
+        "sourceIpGroups": {
+          "type": "array",
+          "description": "List of source IpGroups for this rule.",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "description": "Properties of a NAT rule."
+    },
+    "AzureFirewallNatRCAction": {
+      "properties": {
+        "type": {
+          "description": "The type of action.",
+          "$ref": "#/definitions/AzureFirewallNatRCActionType"
+        }
+      },
+      "description": "AzureFirewall NAT Rule Collection Action."
+    },
+    "AzureFirewallNatRCActionType": {
+      "type": "string",
+      "description": "The action type of a NAT rule collection.",
+      "enum": [
+        "Snat",
+        "Dnat"
+      ],
+      "x-ms-enum": {
+        "name": "AzureFirewallNatRCActionType",
+        "modelAsString": true
+      }
+    },
+    "AzureFirewallNetworkRuleCollectionPropertiesFormat": {
+      "properties": {
+        "priority": {
+          "type": "integer",
+          "format": "int32",
+          "maximum": 65000,
+          "exclusiveMaximum": false,
+          "minimum": 100,
+          "exclusiveMinimum": false,
+          "description": "Priority of the network rule collection resource."
+        },
+        "action": {
+          "$ref": "#/definitions/AzureFirewallRCAction",
+          "description": "The action type of a rule collection."
+        },
+        "rules": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AzureFirewallNetworkRule"
+          },
+          "description": "Collection of rules used by a network rule collection."
+        },
+        "provisioningState": {
+          "readOnly": true,
+          "$ref": "./network.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the network rule collection resource."
+        }
+      },
+      "description": "Properties of the network rule collection."
+    },
+    "AzureFirewallNetworkRuleCollection": {
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/AzureFirewallNetworkRuleCollectionPropertiesFormat",
+          "description": "Properties of the azure firewall network rule collection."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the resource that is unique within the Azure firewall. This name can be used to access the resource."
+        },
+        "etag": {
+          "type": "string",
+          "readOnly": true,
+          "description": "A unique read-only string that changes whenever the resource is updated."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./network.json#/definitions/SubResource"
+        }
+      ],
+      "description": "Network rule collection resource."
+    },
+    "AzureFirewallNetworkRule": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the network rule."
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of the rule."
+        },
+        "protocols": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AzureFirewallNetworkRuleProtocol"
+          },
+          "description": "Array of AzureFirewallNetworkRuleProtocols."
+        },
+        "sourceAddresses": {
+          "type": "array",
+          "description": "List of source IP addresses for this rule.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "destinationAddresses": {
+          "type": "array",
+          "description": "List of destination IP addresses.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "destinationPorts": {
+          "type": "array",
+          "description": "List of destination ports.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "destinationFqdns": {
+          "type": "array",
+          "description": "List of destination FQDNs.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sourceIpGroups": {
+          "type": "array",
+          "description": "List of source IpGroups for this rule.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "destinationIpGroups": {
+          "type": "array",
+          "description": "List of destination IpGroups for this rule.",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "description": "Properties of the network rule."
+    },
+    "AzureFirewallRCAction": {
+      "properties": {
+        "type": {
+          "description": "The type of action.",
+          "$ref": "#/definitions/AzureFirewallRCActionType"
+        }
+      },
+      "description": "Properties of the AzureFirewallRCAction."
+    },
+    "AzureFirewallRCActionType": {
+      "type": "string",
+      "description": "The action type of a rule collection.",
+      "enum": [
+        "Allow",
+        "Deny"
+      ],
+      "x-ms-enum": {
+        "name": "AzureFirewallRCActionType",
+        "modelAsString": true
+      }
+    },
+    "AzureFirewallNetworkRuleProtocol": {
+      "type": "string",
+      "description": "The protocol of a Network Rule resource.",
+      "enum": [
+        "TCP",
+        "UDP",
+        "Any",
+        "ICMP"
+      ],
+      "x-ms-enum": {
+        "name": "AzureFirewallNetworkRuleProtocol",
+        "modelAsString": true
+      }
+    },
+    "AzureFirewallApplicationRuleProtocolType": {
+      "type": "string",
+      "description": "The protocol type of a Application Rule resource.",
+      "enum": [
+        "Http",
+        "Https",
+        "Mssql"
+      ],
+      "x-ms-enum": {
+        "name": "AzureFirewallApplicationRuleProtocolType",
+        "modelAsString": true
+      }
+    },
+    "AzureFirewallSku": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of an Azure Firewall SKU.",
+          "enum": [
+            "AZFW_VNet",
+            "AZFW_Hub"
+          ],
+          "x-ms-enum": {
+            "name": "AzureFirewallSkuName",
+            "modelAsString": true
+          }
+        },
+        "tier": {
+          "type": "string",
+          "description": "Tier of an Azure Firewall.",
+          "enum": [
+            "Standard",
+            "Premium",
+            "Basic"
+          ],
+          "x-ms-enum": {
+            "name": "AzureFirewallSkuTier",
+            "modelAsString": true
+          }
+        }
+      },
+      "description": "SKU of an Azure Firewall."
+    }
+  }
+}

--- a/src/autorest.bicep/test/integration/specs/firewalls/resource-manager/Microsoft.Network/stable/2021-08-01/firewallPolicy.json
+++ b/src/autorest.bicep/test/integration/specs/firewalls/resource-manager/Microsoft.Network/stable/2021-08-01/firewallPolicy.json
@@ -1,0 +1,2143 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "NetworkManagementClient",
+    "description": "The Microsoft Azure Network management API provides a RESTful set of web services that interact with Microsoft Azure Networks service to manage your network resources. The API has entities that capture the relationship between an end user and the Microsoft Azure Networks service.",
+    "version": "2021-08-01"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/firewallPolicies/{firewallPolicyName}": {
+      "delete": {
+        "tags": [
+          "FirewallPolicies"
+        ],
+        "operationId": "FirewallPolicies_Delete",
+        "description": "Deletes the specified Firewall Policy.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "firewallPolicyName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Firewall Policy."
+          },
+          {
+            "$ref": "./network.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "./network.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Accepted and the operation will complete asynchronously."
+          },
+          "204": {
+            "description": "Request successful. Resource with the specified name does not exist."
+          },
+          "200": {
+            "description": "Delete successful."
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "./network.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete Firewall Policy": {
+            "$ref": "./examples/FirewallPolicyDelete.json"
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        }
+      },
+      "get": {
+        "tags": [
+          "FirewallPolicies"
+        ],
+        "operationId": "FirewallPolicies_Get",
+        "description": "Gets the specified Firewall Policy.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "firewallPolicyName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Firewall Policy."
+          },
+          {
+            "$ref": "./network.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "./network.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Expands referenced resources."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns a Firewall Policy resource.",
+            "schema": {
+              "$ref": "#/definitions/FirewallPolicy"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "./network.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get FirewallPolicy": {
+            "$ref": "./examples/FirewallPolicyGet.json"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "FirewallPolicies"
+        ],
+        "operationId": "FirewallPolicies_CreateOrUpdate",
+        "description": "Creates or updates the specified Firewall Policy.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "firewallPolicyName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Firewall Policy."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/FirewallPolicy"
+            },
+            "description": "Parameters supplied to the create or update Firewall Policy operation."
+          },
+          {
+            "$ref": "./network.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "./network.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Request received successfully. The operation returns the resulting FirewallPolicy resource.",
+            "schema": {
+              "$ref": "#/definitions/FirewallPolicy"
+            }
+          },
+          "200": {
+            "description": "Request successful. The operation returns the resulting FirewallPolicy resource.",
+            "schema": {
+              "$ref": "#/definitions/FirewallPolicy"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "./network.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create FirewallPolicy": {
+            "$ref": "./examples/FirewallPolicyPut.json"
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        }
+      },
+      "patch": {
+        "tags": [
+          "FirewallPolicies"
+        ],
+        "operationId": "FirewallPolicies_UpdateTags",
+        "description": "Updates tags of a Azure Firewall Policy resource.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "firewallPolicyName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Firewall Policy."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "./network.json#/definitions/TagsObject"
+            },
+            "description": "Parameters supplied to update Azure Firewall Policy tags."
+          },
+          {
+            "$ref": "./network.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "./network.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns the resulting FirewallPolicy resource.",
+            "schema": {
+              "$ref": "#/definitions/FirewallPolicy"
+            }
+          },
+          "default": {
+            "description": "Unexpected error.",
+            "schema": {
+              "$ref": "./network.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Update FirewallPolicy Tags": {
+            "$ref": "./examples/FirewallPolicyPatch.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/firewallPolicies": {
+      "get": {
+        "tags": [
+          "FirewallPolicies"
+        ],
+        "operationId": "FirewallPolicies_List",
+        "description": "Lists all Firewall Policies in a resource group.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "$ref": "./network.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "./network.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success. The operation returns a list of FirewallPolicy resources.",
+            "schema": {
+              "$ref": "#/definitions/FirewallPolicyListResult"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "./network.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List all Firewall Policies for a given resource group": {
+            "$ref": "./examples/FirewallPolicyListByResourceGroup.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/firewallPolicies": {
+      "get": {
+        "tags": [
+          "FirewallPolicies"
+        ],
+        "operationId": "FirewallPolicies_ListAll",
+        "description": "Gets all the Firewall Policies in a subscription.",
+        "parameters": [
+          {
+            "$ref": "./network.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "./network.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success. The operation returns a list of FirewallPolicy resources.",
+            "schema": {
+              "$ref": "#/definitions/FirewallPolicyListResult"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "./network.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List all Firewall Policies for a given subscription": {
+            "$ref": "./examples/FirewallPolicyListBySubscription.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/firewallPolicies/{firewallPolicyName}/ruleCollectionGroups/{ruleCollectionGroupName}": {
+      "delete": {
+        "tags": [
+          "FirewallPolicyRuleCollectionGroups"
+        ],
+        "operationId": "FirewallPolicyRuleCollectionGroups_Delete",
+        "description": "Deletes the specified FirewallPolicyRuleCollectionGroup.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "firewallPolicyName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Firewall Policy."
+          },
+          {
+            "name": "ruleCollectionGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the FirewallPolicyRuleCollectionGroup."
+          },
+          {
+            "$ref": "./network.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "./network.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Accepted and the operation will complete asynchronously."
+          },
+          "204": {
+            "description": "Request successful. Resource with the specified name does not exist."
+          },
+          "200": {
+            "description": "Delete successful."
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "./network.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete FirewallPolicyRuleCollectionGroup": {
+            "$ref": "./examples/FirewallPolicyRuleCollectionGroupDelete.json"
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        }
+      },
+      "get": {
+        "tags": [
+          "FirewallPolicyRuleCollectionGroups"
+        ],
+        "operationId": "FirewallPolicyRuleCollectionGroups_Get",
+        "description": "Gets the specified FirewallPolicyRuleCollectionGroup.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "firewallPolicyName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Firewall Policy."
+          },
+          {
+            "name": "ruleCollectionGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the FirewallPolicyRuleCollectionGroup."
+          },
+          {
+            "$ref": "./network.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "./network.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successful. The operation returns a FirewallPolicyRuleCollectionGroup resource.",
+            "schema": {
+              "$ref": "#/definitions/FirewallPolicyRuleCollectionGroup"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "./network.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get FirewallPolicyRuleCollectionGroup": {
+            "$ref": "./examples/FirewallPolicyRuleCollectionGroupGet.json"
+          },
+          "Get FirewallPolicyRuleCollectionGroup With IpGroups": {
+            "$ref": "./examples/FirewallPolicyRuleCollectionGroupWithIpGroupsGet.json"
+          },
+          "Get FirewallPolicyNatRuleCollectionGroup": {
+            "$ref": "./examples/FirewallPolicyNatRuleCollectionGroupGet.json"
+          },
+          "Get FirewallPolicyRuleCollectionGroup With Web Categories": {
+            "$ref": "./examples/FirewallPolicyRuleCollectionGroupWithWebCategoriesGet.json"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "FirewallPolicyRuleCollectionGroups"
+        ],
+        "operationId": "FirewallPolicyRuleCollectionGroups_CreateOrUpdate",
+        "description": "Creates or updates the specified FirewallPolicyRuleCollectionGroup.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "firewallPolicyName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Firewall Policy."
+          },
+          {
+            "name": "ruleCollectionGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the FirewallPolicyRuleCollectionGroup."
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/FirewallPolicyRuleCollectionGroup"
+            },
+            "description": "Parameters supplied to the create or update FirewallPolicyRuleCollectionGroup operation."
+          },
+          {
+            "$ref": "./network.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "./network.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Request received successfully. The operation returns the resulting FirewallPolicyRuleCollectionGroup resource.",
+            "schema": {
+              "$ref": "#/definitions/FirewallPolicyRuleCollectionGroup"
+            }
+          },
+          "200": {
+            "description": "Request successful. The operation returns the resulting FirewallPolicyRuleCollectionGroup resource.",
+            "schema": {
+              "$ref": "#/definitions/FirewallPolicyRuleCollectionGroup"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "./network.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create FirewallPolicyRuleCollectionGroup": {
+            "$ref": "./examples/FirewallPolicyRuleCollectionGroupPut.json"
+          },
+          "Create FirewallPolicyRuleCollectionGroup With IpGroups": {
+            "$ref": "./examples/FirewallPolicyRuleCollectionGroupWithIpGroupsPut.json"
+          },
+          "Create FirewallPolicyNatRuleCollectionGroup": {
+            "$ref": "./examples/FirewallPolicyNatRuleCollectionGroupPut.json"
+          },
+          "Create FirewallPolicyRuleCollectionGroup With Web Categories": {
+            "$ref": "./examples/FirewallPolicyRuleCollectionGroupWithWebCategoriesPut.json"
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/firewallPolicies/{firewallPolicyName}/ruleCollectionGroups": {
+      "get": {
+        "tags": [
+          "FirewallPolicyRuleCollectionGroups"
+        ],
+        "operationId": "FirewallPolicyRuleCollectionGroups_List",
+        "description": "Lists all FirewallPolicyRuleCollectionGroups in a FirewallPolicy resource.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "firewallPolicyName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Firewall Policy."
+          },
+          {
+            "$ref": "./network.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "./network.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success. The operation returns a list of FirewallPolicyRuleCollectionGroup resources.",
+            "schema": {
+              "$ref": "#/definitions/FirewallPolicyRuleCollectionGroupListResult"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "./network.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List all FirewallPolicyRuleCollectionGroups for a given FirewallPolicy": {
+            "$ref": "./examples/FirewallPolicyRuleCollectionGroupList.json"
+          },
+          "List all FirewallPolicyRuleCollectionGroups with IpGroups for a given FirewallPolicy": {
+            "$ref": "./examples/FirewallPolicyRuleCollectionGroupWithIpGroupsList.json"
+          },
+          "List all FirewallPolicyRuleCollectionGroup With Web Categories": {
+            "$ref": "./examples/FirewallPolicyRuleCollectionGroupWithWebCategoriesList.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/firewallPolicies/{firewallPolicyName}/listIdpsSignatures": {
+      "post": {
+        "operationId": "FirewallPolicyIdpsSignatures_List",
+        "description": "Retrieves the current status of IDPS signatures for the relevant policy",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "firewallPolicyName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Firewall Policy."
+          },
+          {
+            "$ref": "./network.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/IDPSQueryObject"
+            }
+          },
+          {
+            "$ref": "./network.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success. The operation returns an IDPS Query Response",
+            "schema": {
+              "$ref": "#/definitions/QueryResults"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "./network.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "query signature overrides": {
+            "$ref": "./examples/FirewallPolicyQuerySignatureOverrides.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/firewallPolicies/{firewallPolicyName}/signatureOverrides/default": {
+      "patch": {
+        "operationId": "FirewallPolicyIdpsSignaturesOverrides_Patch",
+        "description": "Will update the status of policy's signature overrides for IDPS",
+        "parameters": [
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "description": "Will contain all properties of the object to put",
+            "schema": {
+              "$ref": "#/definitions/SignaturesOverrides"
+            }
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "firewallPolicyName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Firewall Policy."
+          },
+          {
+            "$ref": "./network.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "./network.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Will return the policy current signature overrides object",
+            "schema": {
+              "$ref": "#/definitions/SignaturesOverrides"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "./network.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "patch signature overrides": {
+            "$ref": "./examples/FirewallPolicySignatureOverridesPatch.json"
+          }
+        }
+      },
+      "put": {
+        "description": "Will override/create a new signature overrides for the policy's IDPS",
+        "operationId": "FirewallPolicyIdpsSignaturesOverrides_Put",
+        "parameters": [
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "description": "Will contain all properties of the object to put",
+            "schema": {
+              "$ref": "#/definitions/SignaturesOverrides"
+            }
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "firewallPolicyName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Firewall Policy."
+          },
+          {
+            "$ref": "./network.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "./network.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Describes the new state of the signature overrides after the PUT operation",
+            "schema": {
+              "$ref": "#/definitions/SignaturesOverrides"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "./network.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "put signature overrides": {
+            "$ref": "./examples/FirewallPolicySignatureOverridesPut.json"
+          }
+        }
+      },
+      "get": {
+        "description": "Returns all signatures overrides for a specific policy.",
+        "operationId": "FirewallPolicyIdpsSignaturesOverrides_Get",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "firewallPolicyName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Firewall Policy."
+          },
+          {
+            "$ref": "./network.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "./network.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Will return the policy current signature overrides object",
+            "schema": {
+              "$ref": "#/definitions/SignaturesOverrides"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "./network.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "get signature overrides": {
+            "$ref": "./examples/FirewallPolicySignatureOverridesGet.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/firewallPolicies/{firewallPolicyName}/listIdpsFilterOptions": {
+      "post": {
+        "operationId": "FirewallPolicyIdpsSignaturesFilterValues_List",
+        "description": "Retrieves the current filter values for the signatures overrides",
+        "parameters": [
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SignatureOverridesFilterValuesQuery"
+            }
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "firewallPolicyName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Firewall Policy."
+          },
+          {
+            "$ref": "./network.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "./network.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success. The operation returns a list of all valid filter values for the requested column",
+            "schema": {
+              "$ref": "#/definitions/SignatureOverridesFilterValuesResponse"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "./network.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "query signature overrides": {
+            "$ref": "./examples/FirewallPolicyQuerySignatureOverridesFilterValues.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/firewallPolicies/{firewallPolicyName}/signatureOverrides": {
+      "get": {
+        "description": "Returns all signatures overrides objects for a specific policy as a list containing a single value.",
+        "operationId": "FirewallPolicyIdpsSignaturesOverrides_List",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "firewallPolicyName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the Firewall Policy."
+          },
+          {
+            "$ref": "./network.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "./network.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Will return the policy current signature overrides object inside a list",
+            "schema": {
+              "$ref": "#/definitions/SignaturesOverridesList"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "./network.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "get signature overrides": {
+            "$ref": "./examples/FirewallPolicySignatureOverridesList.json"
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "FirewallPolicy": {
+      "type": "object",
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/FirewallPolicyPropertiesFormat",
+          "description": "Properties of the firewall policy."
+        },
+        "etag": {
+          "type": "string",
+          "readOnly": true,
+          "description": "A unique read-only string that changes whenever the resource is updated."
+        },
+        "identity": {
+          "$ref": "./network.json#/definitions/ManagedServiceIdentity",
+          "description": "The identity of the firewall policy."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./network.json#/definitions/Resource"
+        }
+      ],
+      "description": "FirewallPolicy Resource."
+    },
+    "FirewallPolicyPropertiesFormat": {
+      "type": "object",
+      "properties": {
+        "ruleCollectionGroups": {
+          "type": "array",
+          "readOnly": true,
+          "description": "List of references to FirewallPolicyRuleCollectionGroups.",
+          "items": {
+            "$ref": "./network.json#/definitions/SubResource"
+          }
+        },
+        "provisioningState": {
+          "readOnly": true,
+          "$ref": "./network.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the firewall policy resource."
+        },
+        "basePolicy": {
+          "readOnly": false,
+          "$ref": "./network.json#/definitions/SubResource",
+          "description": "The parent firewall policy from which rules are inherited."
+        },
+        "firewalls": {
+          "type": "array",
+          "readOnly": true,
+          "description": "List of references to Azure Firewalls that this Firewall Policy is associated with.",
+          "items": {
+            "$ref": "./network.json#/definitions/SubResource"
+          }
+        },
+        "childPolicies": {
+          "type": "array",
+          "readOnly": true,
+          "description": "List of references to Child Firewall Policies.",
+          "items": {
+            "$ref": "./network.json#/definitions/SubResource"
+          }
+        },
+        "threatIntelMode": {
+          "description": "The operation mode for Threat Intelligence.",
+          "$ref": "./azureFirewall.json#/definitions/AzureFirewallThreatIntelMode"
+        },
+        "threatIntelWhitelist": {
+          "description": "ThreatIntel Whitelist for Firewall Policy.",
+          "$ref": "#/definitions/FirewallPolicyThreatIntelWhitelist"
+        },
+        "insights": {
+          "description": "Insights on Firewall Policy.",
+          "$ref": "#/definitions/FirewallPolicyInsights"
+        },
+        "snat": {
+          "description": "The private IP addresses/IP ranges to which traffic will not be SNAT.",
+          "$ref": "#/definitions/FirewallPolicySNAT"
+        },
+        "sql": {
+          "description": "SQL Settings definition.",
+          "$ref": "#/definitions/FirewallPolicySQL"
+        },
+        "dnsSettings": {
+          "description": "DNS Proxy Settings definition.",
+          "$ref": "#/definitions/DnsSettings"
+        },
+        "explicitProxySettings": {
+          "description": "Explicit Proxy Settings definition.",
+          "$ref": "#/definitions/ExplicitProxySettings"
+        },
+        "intrusionDetection": {
+          "description": "The configuration for Intrusion detection.",
+          "$ref": "#/definitions/FirewallPolicyIntrusionDetection"
+        },
+        "transportSecurity": {
+          "description": "TLS Configuration definition.",
+          "$ref": "#/definitions/FirewallPolicyTransportSecurity"
+        },
+        "sku": {
+          "description": "The Firewall Policy SKU.",
+          "$ref": "#/definitions/FirewallPolicySku"
+        }
+      },
+      "description": "Firewall Policy definition."
+    },
+    "FirewallPolicyRuleCollectionGroup": {
+      "type": "object",
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/FirewallPolicyRuleCollectionGroupProperties",
+          "description": "The properties of the firewall policy rule collection group."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource."
+        },
+        "etag": {
+          "type": "string",
+          "readOnly": true,
+          "description": "A unique read-only string that changes whenever the resource is updated."
+        },
+        "type": {
+          "type": "string",
+          "readOnly": true,
+          "description": "Rule Group type."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./network.json#/definitions/SubResource"
+        }
+      ],
+      "description": "Rule Collection Group resource."
+    },
+    "FirewallPolicyRuleCollectionGroupProperties": {
+      "type": "object",
+      "properties": {
+        "priority": {
+          "type": "integer",
+          "format": "int32",
+          "maximum": 65000,
+          "exclusiveMaximum": false,
+          "minimum": 100,
+          "exclusiveMinimum": false,
+          "description": "Priority of the Firewall Policy Rule Collection Group resource."
+        },
+        "ruleCollections": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/FirewallPolicyRuleCollection"
+          },
+          "description": "Group of Firewall Policy rule collections.",
+          "x-ms-identifiers": []
+        },
+        "provisioningState": {
+          "readOnly": true,
+          "$ref": "./network.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the firewall policy rule collection group resource."
+        }
+      },
+      "description": "Properties of the rule collection group."
+    },
+    "FirewallPolicyRuleCollection": {
+      "type": "object",
+      "description": "Properties of the rule collection.",
+      "discriminator": "ruleCollectionType",
+      "required": [
+        "ruleCollectionType"
+      ],
+      "properties": {
+        "ruleCollectionType": {
+          "type": "string",
+          "description": "The type of the rule collection.",
+          "enum": [
+            "FirewallPolicyNatRuleCollection",
+            "FirewallPolicyFilterRuleCollection"
+          ],
+          "x-ms-enum": {
+            "name": "FirewallPolicyRuleCollectionType",
+            "modelAsString": true
+          }
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the rule collection."
+        },
+        "priority": {
+          "type": "integer",
+          "format": "int32",
+          "maximum": 65000,
+          "exclusiveMaximum": false,
+          "minimum": 100,
+          "exclusiveMinimum": false,
+          "description": "Priority of the Firewall Policy Rule Collection resource."
+        }
+      }
+    },
+    "FirewallPolicyNatRuleCollection": {
+      "type": "object",
+      "properties": {
+        "action": {
+          "$ref": "#/definitions/FirewallPolicyNatRuleCollectionAction",
+          "description": "The action type of a Nat rule collection."
+        },
+        "rules": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/FirewallPolicyRule"
+          },
+          "description": "List of rules included in a rule collection.",
+          "x-ms-identifiers": []
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/FirewallPolicyRuleCollection"
+        }
+      ],
+      "x-ms-discriminator-value": "FirewallPolicyNatRuleCollection",
+      "description": "Firewall Policy NAT Rule Collection."
+    },
+    "FirewallPolicyFilterRuleCollection": {
+      "type": "object",
+      "properties": {
+        "action": {
+          "$ref": "#/definitions/FirewallPolicyFilterRuleCollectionAction",
+          "description": "The action type of a Filter rule collection."
+        },
+        "rules": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/FirewallPolicyRule"
+          },
+          "description": "List of rules included in a rule collection.",
+          "x-ms-identifiers": []
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/FirewallPolicyRuleCollection"
+        }
+      ],
+      "x-ms-discriminator-value": "FirewallPolicyFilterRuleCollection",
+      "description": "Firewall Policy Filter Rule Collection."
+    },
+    "FirewallPolicyRule": {
+      "type": "object",
+      "description": "Properties of a rule.",
+      "discriminator": "ruleType",
+      "required": [
+        "ruleType"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the rule."
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of the rule."
+        },
+        "ruleType": {
+          "type": "string",
+          "description": "Rule Type.",
+          "enum": [
+            "ApplicationRule",
+            "NetworkRule",
+            "NatRule"
+          ],
+          "x-ms-enum": {
+            "name": "FirewallPolicyRuleType",
+            "modelAsString": true
+          }
+        }
+      }
+    },
+    "ApplicationRule": {
+      "type": "object",
+      "x-ms-discriminator-value": "ApplicationRule",
+      "allOf": [
+        {
+          "$ref": "#/definitions/FirewallPolicyRule"
+        }
+      ],
+      "properties": {
+        "sourceAddresses": {
+          "type": "array",
+          "description": "List of source IP addresses for this rule.",
+          "items": {
+            "type": "string"
+          },
+          "x-ms-identifiers": []
+        },
+        "destinationAddresses": {
+          "type": "array",
+          "description": "List of destination IP addresses or Service Tags.",
+          "items": {
+            "type": "string"
+          },
+          "x-ms-identifiers": []
+        },
+        "protocols": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/FirewallPolicyRuleApplicationProtocol"
+          },
+          "x-ms-identifiers": [],
+          "description": "Array of Application Protocols."
+        },
+        "targetFqdns": {
+          "type": "array",
+          "description": "List of FQDNs for this rule.",
+          "items": {
+            "type": "string"
+          },
+          "x-ms-identifiers": []
+        },
+        "targetUrls": {
+          "type": "array",
+          "description": "List of Urls for this rule condition.",
+          "items": {
+            "type": "string"
+          },
+          "x-ms-identifiers": []
+        },
+        "fqdnTags": {
+          "type": "array",
+          "description": "List of FQDN Tags for this rule.",
+          "items": {
+            "type": "string"
+          },
+          "x-ms-identifiers": []
+        },
+        "sourceIpGroups": {
+          "type": "array",
+          "description": "List of source IpGroups for this rule.",
+          "items": {
+            "type": "string"
+          },
+          "x-ms-identifiers": []
+        },
+        "terminateTLS": {
+          "type": "boolean",
+          "description": "Terminate TLS connections for this rule."
+        },
+        "webCategories": {
+          "type": "array",
+          "description": "List of destination azure web categories.",
+          "items": {
+            "type": "string"
+          },
+          "x-ms-identifiers": []
+        }
+      },
+      "description": "Rule of type application."
+    },
+    "NatRule": {
+      "type": "object",
+      "description": "Rule of type nat.",
+      "x-ms-discriminator-value": "NatRule",
+      "allOf": [
+        {
+          "$ref": "#/definitions/FirewallPolicyRule"
+        }
+      ],
+      "properties": {
+        "ipProtocols": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/FirewallPolicyRuleNetworkProtocol"
+          },
+          "description": "Array of FirewallPolicyRuleNetworkProtocols."
+        },
+        "sourceAddresses": {
+          "type": "array",
+          "description": "List of source IP addresses for this rule.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "destinationAddresses": {
+          "type": "array",
+          "description": "List of destination IP addresses or Service Tags.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "destinationPorts": {
+          "type": "array",
+          "description": "List of destination ports.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "translatedAddress": {
+          "type": "string",
+          "description": "The translated address for this NAT rule."
+        },
+        "translatedPort": {
+          "type": "string",
+          "description": "The translated port for this NAT rule."
+        },
+        "sourceIpGroups": {
+          "type": "array",
+          "description": "List of source IpGroups for this rule.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "translatedFqdn": {
+          "type": "string",
+          "description": "The translated FQDN for this NAT rule."
+        }
+      }
+    },
+    "NetworkRule": {
+      "type": "object",
+      "description": "Rule of type network.",
+      "x-ms-discriminator-value": "NetworkRule",
+      "allOf": [
+        {
+          "$ref": "#/definitions/FirewallPolicyRule"
+        }
+      ],
+      "properties": {
+        "ipProtocols": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/FirewallPolicyRuleNetworkProtocol"
+          },
+          "description": "Array of FirewallPolicyRuleNetworkProtocols."
+        },
+        "sourceAddresses": {
+          "type": "array",
+          "description": "List of source IP addresses for this rule.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "destinationAddresses": {
+          "type": "array",
+          "description": "List of destination IP addresses or Service Tags.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "destinationPorts": {
+          "type": "array",
+          "description": "List of destination ports.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sourceIpGroups": {
+          "type": "array",
+          "description": "List of source IpGroups for this rule.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "destinationIpGroups": {
+          "type": "array",
+          "description": "List of destination IpGroups for this rule.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "destinationFqdns": {
+          "type": "array",
+          "description": "List of destination FQDNs.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "FirewallPolicyRuleApplicationProtocol": {
+      "type": "object",
+      "properties": {
+        "protocolType": {
+          "description": "Protocol type.",
+          "$ref": "#/definitions/FirewallPolicyRuleApplicationProtocolType"
+        },
+        "port": {
+          "type": "integer",
+          "format": "int32",
+          "maximum": 64000,
+          "exclusiveMaximum": false,
+          "minimum": 0,
+          "exclusiveMinimum": false,
+          "description": "Port number for the protocol, cannot be greater than 64000."
+        }
+      },
+      "description": "Properties of the application rule protocol."
+    },
+    "FirewallPolicyRuleApplicationProtocolType": {
+      "type": "string",
+      "description": "The application protocol type of a Rule.",
+      "enum": [
+        "Http",
+        "Https"
+      ],
+      "x-ms-enum": {
+        "name": "FirewallPolicyRuleApplicationProtocolType",
+        "modelAsString": true
+      }
+    },
+    "FirewallPolicyNatRuleCollectionActionType": {
+      "type": "string",
+      "description": "The action type of a rule.",
+      "enum": [
+        "DNAT"
+      ],
+      "x-ms-enum": {
+        "name": "FirewallPolicyNatRuleCollectionActionType",
+        "modelAsString": true
+      }
+    },
+    "FirewallPolicyNatRuleCollectionAction": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "description": "The type of action.",
+          "$ref": "#/definitions/FirewallPolicyNatRuleCollectionActionType"
+        }
+      },
+      "description": "Properties of the FirewallPolicyNatRuleCollectionAction."
+    },
+    "FirewallPolicyFilterRuleCollectionActionType": {
+      "type": "string",
+      "description": "The action type of a rule.",
+      "enum": [
+        "Allow",
+        "Deny"
+      ],
+      "x-ms-enum": {
+        "name": "FirewallPolicyFilterRuleCollectionActionType",
+        "modelAsString": true
+      }
+    },
+    "FirewallPolicyFilterRuleCollectionAction": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "description": "The type of action.",
+          "$ref": "#/definitions/FirewallPolicyFilterRuleCollectionActionType"
+        }
+      },
+      "description": "Properties of the FirewallPolicyFilterRuleCollectionAction."
+    },
+    "FirewallPolicyRuleNetworkProtocol": {
+      "type": "string",
+      "description": "The Network protocol of a Rule.",
+      "enum": [
+        "TCP",
+        "UDP",
+        "Any",
+        "ICMP"
+      ],
+      "x-ms-enum": {
+        "name": "FirewallPolicyRuleNetworkProtocol",
+        "modelAsString": true
+      }
+    },
+    "FirewallPolicyListResult": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/FirewallPolicy"
+          },
+          "description": "List of Firewall Policies in a resource group."
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "URL to get the next set of results."
+        }
+      },
+      "description": "Response for ListFirewallPolicies API service call."
+    },
+    "FirewallPolicyRuleCollectionGroupListResult": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/FirewallPolicyRuleCollectionGroup"
+          },
+          "description": "List of FirewallPolicyRuleCollectionGroups in a FirewallPolicy."
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "URL to get the next set of results."
+        }
+      },
+      "description": "Response for ListFirewallPolicyRuleCollectionGroups API service call."
+    },
+    "FirewallPolicyThreatIntelWhitelist": {
+      "type": "object",
+      "description": "ThreatIntel Whitelist for Firewall Policy.",
+      "properties": {
+        "ipAddresses": {
+          "type": "array",
+          "description": "List of IP addresses for the ThreatIntel Whitelist.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "fqdns": {
+          "type": "array",
+          "description": "List of FQDNs for the ThreatIntel Whitelist.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "FirewallPolicyInsights": {
+      "type": "object",
+      "description": "Firewall Policy Insights.",
+      "properties": {
+        "isEnabled": {
+          "type": "boolean",
+          "description": "A flag to indicate if the insights are enabled on the policy."
+        },
+        "retentionDays": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of days the insights should be enabled on the policy."
+        },
+        "logAnalyticsResources": {
+          "description": "Workspaces needed to configure the Firewall Policy Insights.",
+          "$ref": "#/definitions/FirewallPolicyLogAnalyticsResources"
+        }
+      }
+    },
+    "FirewallPolicySNAT": {
+      "type": "object",
+      "description": "The private IP addresses/IP ranges to which traffic will not be SNAT.",
+      "properties": {
+        "privateRanges": {
+          "type": "array",
+          "description": "List of private IP addresses/IP address ranges to not be SNAT.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "FirewallPolicySQL": {
+      "type": "object",
+      "description": "SQL Settings in Firewall Policy.",
+      "properties": {
+        "allowSqlRedirect": {
+          "type": "boolean",
+          "description": "A flag to indicate if SQL Redirect traffic filtering is enabled. Turning on the flag requires no rule using port 11000-11999."
+        }
+      }
+    },
+    "DnsSettings": {
+      "type": "object",
+      "description": "DNS Proxy Settings in Firewall Policy.",
+      "properties": {
+        "servers": {
+          "type": "array",
+          "description": "List of Custom DNS Servers.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "enableProxy": {
+          "type": "boolean",
+          "description": "Enable DNS Proxy on Firewalls attached to the Firewall Policy."
+        },
+        "requireProxyForNetworkRules": {
+          "type": "boolean",
+          "description": "FQDNs in Network Rules are supported when set to true.",
+          "x-nullable": true
+        }
+      }
+    },
+    "ExplicitProxySettings": {
+      "description": "Explicit Proxy Settings in Firewall Policy.",
+      "type": "object",
+      "properties": {
+        "enableExplicitProxy": {
+          "type": "boolean",
+          "description": "When set to true, explicit proxy mode is enabled.",
+          "x-nullable": true
+        },
+        "httpPort": {
+          "type": "integer",
+          "format": "int32",
+          "maximum": 64000,
+          "exclusiveMaximum": false,
+          "minimum": 0,
+          "exclusiveMinimum": false,
+          "description": "Port number for explicit proxy http protocol, cannot be greater than 64000."
+        },
+        "httpsPort": {
+          "type": "integer",
+          "format": "int32",
+          "maximum": 64000,
+          "exclusiveMaximum": false,
+          "minimum": 0,
+          "exclusiveMinimum": false,
+          "description": "Port number for explicit proxy https protocol, cannot be greater than 64000."
+        },
+        "pacFilePort": {
+          "type": "integer",
+          "format": "int32",
+          "maximum": 64000,
+          "exclusiveMaximum": false,
+          "minimum": 0,
+          "exclusiveMinimum": false,
+          "description": "Port number for firewall to serve PAC file."
+        },
+        "pacFile": {
+          "type": "string",
+          "description": "SAS URL for PAC file."
+        }
+      }
+    },
+    "FirewallPolicyIntrusionDetection": {
+      "type": "object",
+      "description": "Configuration for intrusion detection mode and rules.",
+      "properties": {
+        "mode": {
+          "$ref": "#/definitions/FirewallPolicyIntrusionDetectionStateOptions",
+          "description": "Intrusion detection general state."
+        },
+        "configuration": {
+          "$ref": "#/definitions/FirewallPolicyIntrusionDetectionConfiguration",
+          "description": "Intrusion detection configuration properties."
+        }
+      }
+    },
+    "FirewallPolicyIntrusionDetectionStateOptions": {
+      "type": "string",
+      "description": "Possible state values.",
+      "enum": [
+        "Off",
+        "Alert",
+        "Deny"
+      ],
+      "x-ms-enum": {
+        "name": "FirewallPolicyIntrusionDetectionStateType",
+        "modelAsString": true
+      }
+    },
+    "FirewallPolicyIntrusionDetectionConfiguration": {
+      "type": "object",
+      "description": "The operation for configuring intrusion detection.",
+      "properties": {
+        "signatureOverrides": {
+          "type": "array",
+          "description": "List of specific signatures states.",
+          "items": {
+            "$ref": "#/definitions/FirewallPolicyIntrusionDetectionSignatureSpecification"
+          }
+        },
+        "bypassTrafficSettings": {
+          "type": "array",
+          "description": "List of rules for traffic to bypass.",
+          "items": {
+            "$ref": "#/definitions/FirewallPolicyIntrusionDetectionBypassTrafficSpecifications"
+          },
+          "x-ms-identifiers": []
+        },
+        "privateRanges": {
+          "type": "array",
+          "description": "IDPS Private IP address ranges are used to identify traffic direction (i.e. inbound, outbound, etc.). By default, only ranges defined by IANA RFC 1918 are considered private IP addresses. To modify default ranges, specify your Private IP address ranges with this property",
+          "items": {
+            "type": "string"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "FirewallPolicyIntrusionDetectionSignatureSpecification": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Signature id."
+        },
+        "mode": {
+          "$ref": "#/definitions/FirewallPolicyIntrusionDetectionStateOptions",
+          "description": "The signature state."
+        }
+      },
+      "description": "Intrusion detection signatures specification states."
+    },
+    "FirewallPolicyIntrusionDetectionBypassTrafficSpecifications": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the bypass traffic rule."
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of the bypass traffic rule."
+        },
+        "protocol": {
+          "type": "string",
+          "$ref": "#/definitions/FirewallPolicyIntrusionDetectionBypassTrafficProtocol",
+          "description": "The rule bypass protocol."
+        },
+        "sourceAddresses": {
+          "type": "array",
+          "description": "List of source IP addresses or ranges for this rule.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "destinationAddresses": {
+          "type": "array",
+          "description": "List of destination IP addresses or ranges for this rule.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "destinationPorts": {
+          "type": "array",
+          "description": "List of destination ports or ranges.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sourceIpGroups": {
+          "type": "array",
+          "description": "List of source IpGroups for this rule.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "destinationIpGroups": {
+          "type": "array",
+          "description": "List of destination IpGroups for this rule.",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "description": "Intrusion detection bypass traffic specification."
+    },
+    "FirewallPolicyIntrusionDetectionBypassTrafficProtocol": {
+      "type": "string",
+      "description": "Possible intrusion detection bypass traffic protocols.",
+      "enum": [
+        "TCP",
+        "UDP",
+        "ICMP",
+        "ANY"
+      ],
+      "x-ms-enum": {
+        "name": "FirewallPolicyIntrusionDetectionProtocol",
+        "modelAsString": true
+      }
+    },
+    "FirewallPolicyTransportSecurity": {
+      "type": "object",
+      "properties": {
+        "certificateAuthority": {
+          "$ref": "#/definitions/FirewallPolicyCertificateAuthority",
+          "description": "The CA used for intermediate CA generation."
+        }
+      },
+      "description": "Configuration needed to perform TLS termination & initiation."
+    },
+    "FirewallPolicyCertificateAuthority": {
+      "type": "object",
+      "properties": {
+        "keyVaultSecretId": {
+          "type": "string",
+          "description": "Secret Id of (base-64 encoded unencrypted pfx) 'Secret' or 'Certificate' object stored in KeyVault."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the CA certificate."
+        }
+      },
+      "description": "Trusted Root certificates properties for tls."
+    },
+    "FirewallPolicySku": {
+      "type": "object",
+      "properties": {
+        "tier": {
+          "type": "string",
+          "description": "Tier of Firewall Policy.",
+          "enum": [
+            "Standard",
+            "Premium",
+            "Basic"
+          ],
+          "x-ms-enum": {
+            "name": "FirewallPolicySkuTier",
+            "modelAsString": true
+          }
+        }
+      },
+      "description": "SKU of Firewall policy."
+    },
+    "FirewallPolicyLogAnalyticsResources": {
+      "type": "object",
+      "description": "Log Analytics Resources for Firewall Policy Insights.",
+      "properties": {
+        "workspaces": {
+          "type": "array",
+          "description": "List of workspaces for Firewall Policy Insights.",
+          "items": {
+            "$ref": "#/definitions/FirewallPolicyLogAnalyticsWorkspace"
+          },
+          "x-ms-identifiers": []
+        },
+        "defaultWorkspaceId": {
+          "$ref": "./network.json#/definitions/SubResource",
+          "description": "The default workspace Id for Firewall Policy Insights."
+        }
+      }
+    },
+    "FirewallPolicyLogAnalyticsWorkspace": {
+      "type": "object",
+      "description": "Log Analytics Workspace for Firewall Policy Insights.",
+      "properties": {
+        "region": {
+          "type": "string",
+          "description": "Region to configure the Workspace."
+        },
+        "workspaceId": {
+          "$ref": "./network.json#/definitions/SubResource",
+          "description": "The workspace Id for Firewall Policy Insights."
+        }
+      }
+    },
+    "IDPSQueryObject": {
+      "description": "Will describe the query to run against the IDPS signatures DB",
+      "type": "object",
+      "properties": {
+        "filters": {
+          "type": "object",
+          "description": "Contain all filters names and values",
+          "$ref": "#/definitions/Filters"
+        },
+        "search": {
+          "type": "string",
+          "description": "Search term in all columns"
+        },
+        "orderBy": {
+          "type": "object",
+          "$ref": "#/definitions/OrderBy",
+          "description": "Column to sort response by"
+        },
+        "resultsPerPage": {
+          "type": "integer",
+          "format": "int32",
+          "minimum": 1,
+          "maximum": 1000,
+          "description": "The number of the results to return in each page"
+        },
+        "skip": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The number of records matching the filter to skip"
+        }
+      }
+    },
+    "Filters": {
+      "description": "Describers the filters to filter response by",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/FilterItems"
+      },
+      "x-ms-identifiers": []
+    },
+    "FilterItems": {
+      "description": "Will contain the filter name and values to operate on",
+      "type": "object",
+      "properties": {
+        "field": {
+          "type": "string",
+          "description": "The name of the field we would like to filter"
+        },
+        "values": {
+          "type": "array",
+          "description": "List of values to filter the current field by",
+          "items": {
+            "type": "string",
+            "description": "Value of the field to filter by"
+          }
+        }
+      }
+    },
+    "OrderBy": {
+      "description": "Describes a column to sort",
+      "type": "object",
+      "properties": {
+        "field": {
+          "type": "string",
+          "description": "Describes the actual column name to sort by"
+        },
+        "order": {
+          "type": "string",
+          "description": "Describes if results should be in ascending/descending order",
+          "enum": [
+            "Ascending",
+            "Descending"
+          ],
+          "x-ms-enum": {
+            "name": "FirewallPolicyIDPSQuerySortOrder",
+            "modelAsString": true
+          }
+        }
+      }
+    },
+    "QueryResults": {
+      "description": "Query result",
+      "type": "object",
+      "properties": {
+        "matchingRecordsCount": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Number of total records matching the query."
+        },
+        "signatures": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SingleQueryResult"
+          },
+          "description": "Array containing the results of the query",
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "SingleQueryResult": {
+      "type": "object",
+      "properties": {
+        "signatureId": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The ID of the signature"
+        },
+        "mode": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The current mode enforced, 0 - Disabled, 1 - Alert, 2 -Deny",
+          "enum": [
+            0,
+            1,
+            2
+          ],
+          "x-ms-enum": {
+            "name": "FirewallPolicyIDPSSignatureMode",
+            "modelAsString": false
+          }
+        },
+        "severity": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Describes the severity of signature: 1 - Low, 2 - Medium, 3 - High",
+          "enum": [
+            1,
+            2,
+            3
+          ],
+          "x-ms-enum": {
+            "name": "FirewallPolicyIDPSSignatureSeverity",
+            "modelAsString": false
+          }
+        },
+        "direction": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Describes in which direction signature is being enforced: 0 - Inbound, 1 - OutBound, 2 - Bidirectional",
+          "enum": [
+            0,
+            1,
+            2
+          ],
+          "x-ms-enum": {
+            "name": "FirewallPolicyIDPSSignatureDirection",
+            "modelAsString": false
+          }
+        },
+        "group": {
+          "type": "string",
+          "description": "Describes the groups the signature belongs to"
+        },
+        "description": {
+          "type": "string",
+          "description": "Describes what is the signature enforces"
+        },
+        "protocol": {
+          "type": "string",
+          "description": "Describes the protocol the signatures is being enforced in"
+        },
+        "sourcePorts": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PortsList"
+          },
+          "description": "Describes the list of source ports related to this signature"
+        },
+        "destinationPorts": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PortsList"
+          },
+          "description": "Describes the list of destination ports related to this signature"
+        },
+        "lastUpdated": {
+          "type": "string",
+          "description": "Describes the last updated time of the signature (provided from 3rd party vendor)"
+        },
+        "inheritedFromParentPolicy": {
+          "type": "boolean",
+          "description": "Describes if this override is inherited from base policy or not"
+        }
+      }
+    },
+    "PortsList": {
+      "type": "string",
+      "description": "Describes a port, port range, or negation of a port"
+    },
+    "Signatures": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "SignaturesOverridesList": {
+      "type": "object",
+      "description": "Describes an object containing an array with a single item",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "Describes a list consisting exactly one item describing the policy's signature override status",
+          "items": {
+            "description": "Describes the single signatures overrides object related to that policy.",
+            "$ref": "#/definitions/SignaturesOverrides"
+          }
+        }
+      }
+    },
+    "SignaturesOverrides": {
+      "x-ms-azure-resource": true,
+      "type": "object",
+      "description": "Contains all specific policy signatures overrides for the IDPS",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Contains the name of the resource (default)"
+        },
+        "id": {
+          "description": "Will contain the resource id of the signature override resource",
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "description": "Will contain the type of the resource: Microsoft.Network/firewallPolicies/intrusionDetectionSignaturesOverrides"
+        },
+        "properties": {
+          "type": "object",
+          "description": "Will contain the properties of the resource (the actual signature overrides)",
+          "properties": {
+            "signatures": {
+              "type": "object",
+              "$ref": "#/definitions/Signatures"
+            }
+          }
+        }
+      }
+    },
+    "SignatureOverridesFilterValuesQuery": {
+      "description": "Describes the filter values possibles for a given column",
+      "type": "object",
+      "properties": {
+        "filterName": {
+          "type": "string",
+          "description": "Describes the name of the column which values will be returned"
+        }
+      }
+    },
+    "SignatureOverridesFilterValuesResponse": {
+      "description": "Describes the list of all possible values for a specific filter value",
+      "type": "object",
+      "properties": {
+        "filterValues": {
+          "description": "Describes the possible values",
+          "type": "array",
+          "items": {
+            "description": "Describes a single value of the filter",
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/autorest.bicep/test/integration/specs/firewalls/resource-manager/Microsoft.Network/stable/2021-08-01/network.json
+++ b/src/autorest.bicep/test/integration/specs/firewalls/resource-manager/Microsoft.Network/stable/2021-08-01/network.json
@@ -1,0 +1,359 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "NetworkManagementClient",
+    "description": "The Microsoft Azure Network management API provides a RESTful set of web services that interact with Microsoft Azure Networks service to manage your network resources. The API has entities that capture the relationship between an end user and the Microsoft Azure Networks service.",
+    "version": "2021-08-01"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "paths": {},
+  "definitions": {
+    "ErrorDetails": {
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "Error code."
+        },
+        "target": {
+          "type": "string",
+          "description": "Error target."
+        },
+        "message": {
+          "type": "string",
+          "description": "Error message."
+        }
+      },
+      "description": "Common error details representation."
+    },
+    "Error": {
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "Error code."
+        },
+        "message": {
+          "type": "string",
+          "description": "Error message."
+        },
+        "target": {
+          "type": "string",
+          "description": "Error target."
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ErrorDetails"
+          },
+          "description": "Error details."
+        },
+        "innerError": {
+          "type": "string",
+          "description": "Inner error message."
+        }
+      },
+      "description": "Common error representation."
+    },
+    "CloudError": {
+      "x-ms-external": true,
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/CloudErrorBody",
+          "description": "Cloud error body."
+        }
+      },
+      "description": "An error response from the service."
+    },
+    "CloudErrorBody": {
+      "x-ms-external": true,
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "An identifier for the error. Codes are invariant and are intended to be consumed programmatically."
+        },
+        "message": {
+          "type": "string",
+          "description": "A message describing the error, intended to be suitable for display in a user interface."
+        },
+        "target": {
+          "type": "string",
+          "description": "The target of the particular error. For example, the name of the property in error."
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/CloudErrorBody"
+          },
+          "description": "A list of additional details about the error."
+        }
+      },
+      "description": "An error response from the service."
+    },
+    "AzureAsyncOperationResult": {
+      "properties": {
+        "status": {
+          "type": "string",
+          "description": "Status of the Azure async operation.",
+          "enum": [
+            "InProgress",
+            "Succeeded",
+            "Failed"
+          ],
+          "x-ms-enum": {
+            "name": "NetworkOperationStatus",
+            "modelAsString": true
+          }
+        },
+        "error": {
+          "$ref": "#/definitions/Error",
+          "description": "Details of the error occurred during specified asynchronous operation."
+        }
+      },
+      "description": "The response body contains the status of the specified asynchronous operation, indicating whether it has succeeded, is in progress, or has failed. Note that this status is distinct from the HTTP status code returned for the Get Operation Status operation itself. If the asynchronous operation succeeded, the response body includes the HTTP status code for the successful request. If the asynchronous operation failed, the response body includes the HTTP status code for the failed request and error information regarding the failure."
+    },
+    "Resource": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Resource ID."
+        },
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource name."
+        },
+        "type": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource type."
+        },
+        "location": {
+          "type": "string",
+          "description": "Resource location."
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Resource tags."
+        }
+      },
+      "description": "Common resource representation.",
+      "x-ms-azure-resource": true
+    },
+    "SubResource": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Resource ID."
+        }
+      },
+      "description": "Reference to another subresource.",
+      "x-ms-azure-resource": true
+    },
+    "TagsObject": {
+      "properties": {
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Resource tags."
+        }
+      },
+      "description": "Tags object for patch operations."
+    },
+    "ManagedServiceIdentity": {
+      "properties": {
+        "principalId": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The principal id of the system assigned identity. This property will only be provided for a system assigned identity."
+        },
+        "tenantId": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The tenant id of the system assigned identity. This property will only be provided for a system assigned identity."
+        },
+        "type": {
+          "type": "string",
+          "description": "The type of identity used for the resource. The type 'SystemAssigned, UserAssigned' includes both an implicitly created identity and a set of user assigned identities. The type 'None' will remove any identities from the virtual machine.",
+          "enum": [
+            "SystemAssigned",
+            "UserAssigned",
+            "SystemAssigned, UserAssigned",
+            "None"
+          ],
+          "x-ms-enum": {
+            "name": "ResourceIdentityType",
+            "modelAsString": false
+          }
+        },
+        "userAssignedIdentities": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "principalId": {
+                "readOnly": true,
+                "type": "string",
+                "description": "The principal id of user assigned identity."
+              },
+              "clientId": {
+                "readOnly": true,
+                "type": "string",
+                "description": "The client id of user assigned identity."
+              }
+            }
+          },
+          "description": "The list of user identities associated with resource. The user identity dictionary key references will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'."
+        }
+      },
+      "description": "Identity for the resource."
+    },
+    "ProvisioningState": {
+      "type": "string",
+      "readOnly": true,
+      "description": "The current provisioning state.",
+      "enum": [
+        "Succeeded",
+        "Updating",
+        "Deleting",
+        "Failed"
+      ],
+      "x-ms-enum": {
+        "name": "ProvisioningState",
+        "modelAsString": true
+      }
+    },
+    "Access": {
+      "type": "string",
+      "description": "Access to be allowed or denied.",
+      "enum": [
+        "Allow",
+        "Deny"
+      ],
+      "x-ms-enum": {
+        "name": "Access",
+        "modelAsString": true
+      }
+    },
+    "AuthenticationMethod": {
+      "type": "string",
+      "description": "VPN client authentication method.",
+      "enum": [
+        "EAPTLS",
+        "EAPMSCHAPv2"
+      ],
+      "x-ms-enum": {
+        "name": "AuthenticationMethod",
+        "modelAsString": true
+      }
+    },
+    "IPAllocationMethod": {
+      "type": "string",
+      "description": "IP address allocation method.",
+      "enum": [
+        "Static",
+        "Dynamic"
+      ],
+      "x-ms-enum": {
+        "name": "IPAllocationMethod",
+        "modelAsString": true
+      }
+    },
+    "IPVersion": {
+      "type": "string",
+      "description": "IP address version.",
+      "enum": [
+        "IPv4",
+        "IPv6"
+      ],
+      "x-ms-enum": {
+        "name": "IPVersion",
+        "modelAsString": true
+      }
+    },
+    "ExtendedLocationType": {
+      "type": "string",
+      "description": "The supported ExtendedLocation types. Currently only EdgeZone is supported in Microsoft.Network resources.",
+      "enum": [
+        "EdgeZone"
+      ],
+      "x-ms-enum": {
+        "name": "ExtendedLocationTypes",
+        "modelAsString": true
+      }
+    },
+    "ExtendedLocation": {
+      "description": "ExtendedLocation complex type.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the extended location."
+        },
+        "type": {
+          "$ref": "#/definitions/ExtendedLocationType",
+          "description": "The type of the extended location."
+        }
+      }
+    }
+  },
+  "parameters": {
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription ID forms part of the URI for every service call."
+    },
+    "ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "required": true,
+      "type": "string",
+      "description": "Client API version."
+    },
+    "ApiVersionVmssParameter": {
+      "name": "api-version",
+      "in": "query",
+      "required": true,
+      "type": "string",
+      "enum": [
+        "2017-03-30"
+      ],
+      "x-ms-enum": {
+        "name": "ApiVersion",
+        "modelAsString": true
+      },
+      "description": "Client API version."
+    }
+  }
+}

--- a/src/autorest.bicep/test/integration/specs/firewalls/resource-manager/README.md
+++ b/src/autorest.bicep/test/integration/specs/firewalls/resource-manager/README.md
@@ -1,0 +1,21 @@
+# basic
+
+## Configuration
+
+### Information
+
+```yaml
+title: Basic
+description: Contains a set of basic spec samples for integration tests
+openapi-type: arm
+tag: package-2021-08-01
+```
+
+### Tag: package-2021-08-01
+
+These settings apply only when `--tag=package-2021-08-01` is specified on the command line.
+
+```yaml $(tag) == 'package-2021-08-01'
+input-file:
+  - Microsoft.Network/stable/2021-08-01/firewallPolicy.json
+```


### PR DESCRIPTION
Noticed when integrating the latest schemas into Deployments that we are currently omitting the "discriminator" field. This causes problems with Export Template - this PR corrects that.