### PR TITLE
Avoid clearing stale type folders when used with `--single-path` flag

### DIFF
--- a/src/generator/src/cmd/generate.ts
+++ b/src/generator/src/cmd/generate.ts
@@ -107,11 +107,14 @@ ${err}
   // build the type index
   await buildTypeIndex(defaultLogger, outputBaseDir);
 
-  // log if there are any type dirs with no corresponding readme (e.g. if a swagger directory has been removed).
-  const shouldRebuildTypeIndex = await clearStaleTypeFolders(defaultLogger, outputBaseDir, specsPath, readmePaths);
-  
-  if (shouldRebuildTypeIndex) {
-    await buildTypeIndex(defaultLogger, outputBaseDir);
+  // we only want to clear stale type folders if re-generating the full directory
+  if (!singlePath) {
+    // log if there are any type dirs with no corresponding readme (e.g. if a swagger directory has been removed).
+    const shouldRebuildTypeIndex = await clearStaleTypeFolders(defaultLogger, outputBaseDir, specsPath, readmePaths);
+    
+    if (shouldRebuildTypeIndex) {
+      await buildTypeIndex(defaultLogger, outputBaseDir);
+    }
   }
 });
 


### PR DESCRIPTION
Noticed under #2284. The "stale folder cleanup" logic scans the specs repo. If it's run using `--single-path` against an older version of the specs repo, this will remove folders that were previously valid.