### PR TITLE
Generate Bicep samples from examples

### DIFF
--- a/src/autorest.bicep/src/main.ts
+++ b/src/autorest.bicep/src/main.ts
@@ -26,8 +26,11 @@ export async function processRequest(host: AutorestExtensionHost) {
       if (!session.configuration["arm-schema"]) {
         const types = generateTypes(host, definition);
 
-        // write samples.md
-        host.writeFile({ filename: `${outFolder}/samples.md`, content: getSampleMarkdown(definition) });
+        const samplesMd = getSampleMarkdown(definition);
+        if (samplesMd) {
+          // write samples.md
+          host.writeFile({ filename: `${outFolder}/samples.md`, content: samplesMd });
+        }
   
         // write types.json
         host.writeFile({ filename: `${outFolder}/types.json`, content: writeTypesJson(types) });

--- a/src/autorest.bicep/src/main.ts
+++ b/src/autorest.bicep/src/main.ts
@@ -7,6 +7,7 @@ import { generateSchema } from "./schema-generator";
 import { CodeModel, codeModelSchema } from "@autorest/codemodel";
 import { writeTypesJson, writeMarkdown } from "bicep-types";
 import { getProviderDefinitions } from "./resources";
+import { getSampleMarkdown } from "./sample-generator";
 
 export async function processRequest(host: AutorestExtensionHost) {
   try {
@@ -24,11 +25,14 @@ export async function processRequest(host: AutorestExtensionHost) {
 
       if (!session.configuration["arm-schema"]) {
         const types = generateTypes(host, definition);
+
+        // write samples.md
+        host.writeFile({ filename: `${outFolder}/samples.md`, content: getSampleMarkdown(definition) });
   
         // write types.json
         host.writeFile({ filename: `${outFolder}/types.json`, content: writeTypesJson(types) });
   
-        // writer types.md
+        // write types.md
         host.writeFile({ filename: `${outFolder}/types.md`, content: writeMarkdown(types, `${namespace} @ ${apiVersion}`) });  
       } else {
         const schema = generateSchema(host, definition);

--- a/src/autorest.bicep/src/resources.ts
+++ b/src/autorest.bicep/src/resources.ts
@@ -553,12 +553,11 @@ export function getProviderDefinitions(codeModel: CodeModel, host: AutorestExten
     }
 
     const putExamples: PutExample[] = [];
-    for (const description of keys(examples)) {
+    for (const description in examples) {
       const example = examples[description];
       const bodyParam = requestSchema.parameters.filter(p => (p.protocol.http as HttpParameter)?.in === ParameterLocation.Body)[0];
       const bodyParamName = bodyParam.language.default.name;
-      const body = example.parameters[bodyParamName];
-
+      const body = example?.parameters?.[bodyParamName];
       if (!body) {
         continue;
       }

--- a/src/autorest.bicep/src/resources.ts
+++ b/src/autorest.bicep/src/resources.ts
@@ -7,6 +7,11 @@ import { keys, Dictionary, values, groupBy, uniqBy, chain, flatten } from 'lodas
 import { success, failure, Result } from './utils';
 import { ScopeType } from "bicep-types";
 
+export interface PutExample {
+  description: string;
+  body: Record<string, unknown>;
+}
+
 export interface ResourceDescriptor {
   scopeType: ScopeType;
   namespace: string;
@@ -35,6 +40,7 @@ export interface ResourceDefinition {
   descriptor: ResourceDescriptor;
   putOperation?: ResourceOperationDefintion;
   getOperation?: ResourceOperationDefintion;
+  putExamples?: PutExample[];
 }
 
 export interface ResourceListActionDefinition {
@@ -405,7 +411,8 @@ export function getProviderDefinitions(codeModel: CodeModel, host: AutorestExten
               requestSchema: (getData?.requestSchema instanceof ObjectSchema) ? getData.requestSchema : undefined,
               responseSchema: (getData?.responseSchema instanceof ObjectSchema) ? getData.responseSchema : undefined,
             }
-            : undefined
+            : undefined,
+          putExamples: putData?.putExamples,
         };
 
         const lcNamespace = descriptor.namespace.toLowerCase();
@@ -536,6 +543,7 @@ export function getProviderDefinitions(codeModel: CodeModel, host: AutorestExten
   }
 
   function getPutSchema(operation?: Operation) {
+    const examples = operation?.extensions?.['x-ms-examples'] ?? {};
     const requests = operation?.requests ?? [];
     const validRequests = requests.filter(r => (r.protocol.http as HttpRequest)?.method === HttpMethod.Put);
     const requestSchema = getRequestSchema(operation, validRequests);
@@ -544,12 +552,30 @@ export function getProviderDefinitions(codeModel: CodeModel, host: AutorestExten
       return;
     }
 
+    const putExamples: PutExample[] = [];
+    for (const description of keys(examples)) {
+      const example = examples[description];
+      const bodyParam = requestSchema.parameters.filter(p => (p.protocol.http as HttpParameter)?.in === ParameterLocation.Body)[0];
+      const bodyParamName = bodyParam.language.default.name;
+      const body = example.parameters[bodyParamName];
+
+      if (!body) {
+        continue;
+      }
+
+      putExamples.push({
+        description,
+        body,
+      });
+    }
+
     return {
       request: requestSchema.request,
       response: responseSchema?.response,
       parameters: requestSchema.parameters,
       requestSchema: requestSchema.schema,
       responseSchema: responseSchema?.schema,
+      putExamples,
     };
   }
 
@@ -834,6 +860,7 @@ export function getProviderDefinitions(codeModel: CodeModel, host: AutorestExten
           },
           putOperation: chain(atPath).map(r => r.putOperation).find().value(),
           getOperation: chain(atPath).map(r => r.getOperation).find().value(),
+          putExamples: atPath.flatMap(r => r.putExamples ?? []),
         }];
       }
     }

--- a/src/autorest.bicep/src/sample-generator.ts
+++ b/src/autorest.bicep/src/sample-generator.ts
@@ -4,9 +4,8 @@
 import { getFullyQualifiedType, ProviderDefinition, PutExample, ResourceDescriptor } from "./resources";
 
 export function getSampleMarkdown(definition: ProviderDefinition) {
-  let mdSamples = `
-# ${definition.namespace}
-`;
+  let hasSamples = false;
+  let mdSamples = `# ${definition.namespace}\n`;
 
   for (const resourceType in definition.resourcesByType) {
     const descriptor = definition.resourcesByType[resourceType][0].descriptor;
@@ -25,6 +24,7 @@ export function getSampleMarkdown(definition: ProviderDefinition) {
         continue;
       }
 
+      hasSamples = true;
       mdSamples += `
 ${example.description}
 \`\`\`bicep
@@ -34,7 +34,7 @@ ${bicepContent}
     }
   }
 
-  return mdSamples;
+  return hasSamples ? mdSamples : null;
 }
 
 function generateBicepSample(provider: ProviderDefinition, descriptor: ResourceDescriptor, example: PutExample) {

--- a/src/autorest.bicep/src/sample-generator.ts
+++ b/src/autorest.bicep/src/sample-generator.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { keys } from 'lodash';
 import { getFullyQualifiedType, ProviderDefinition, PutExample, ResourceDescriptor } from "./resources";
 
 export function getSampleMarkdown(definition: ProviderDefinition) {
@@ -9,7 +8,7 @@ export function getSampleMarkdown(definition: ProviderDefinition) {
 # ${definition.namespace}
 `;
 
-  for (const resourceType of keys(definition.resourcesByType)) {
+  for (const resourceType in definition.resourcesByType) {
     const descriptor = definition.resourcesByType[resourceType][0].descriptor;
     const putExamples = definition.resourcesByType[resourceType].flatMap(x => x.putExamples ?? []);
     if (putExamples.length === 0) {
@@ -49,7 +48,7 @@ function generateBicepSample(provider: ProviderDefinition, descriptor: ResourceD
   }
   result += `  name: 'example'\n`;
 
-  for (const propName of keys(example.body)) {
+  for (const propName in example.body) {
     result += `  ${propName}: ${getBicep(example.body[propName], 1)}\n`;
   }
 
@@ -62,6 +61,7 @@ function getIndent(indent: number) {
   return '  '.repeat(indent);
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function getBicep(value: any, indent: number) {
   if (typeof value === 'string') {
     return getBicepString(value);
@@ -87,7 +87,7 @@ function getBicep(value: any, indent: number) {
 
   if (typeof value === 'object') {
     let result = `{`;
-    for (const key of keys(value)) {
+    for (const key in value) {
       result += `\n${getIndent(indent + 1)}${key}: ${getBicep(value[key], indent + 1)}`;
     }
     result += `\n${getIndent(indent)}}`;
@@ -100,11 +100,11 @@ function getBicep(value: any, indent: number) {
 
 function getBicepString(value: string) {
   const escaped = value
-  .replace("\\", "\\\\") // must do this first!
-  .replace("\r", "\\r")
-  .replace("\n", "\\n")
-  .replace("\t", "\\t")
-  .replace("${", "\\${")
-  .replace("'", "\\'");
+  .replace(/\\/g, "\\\\") // must do this first!
+  .replace(/\r/g, "\\r")
+  .replace(/\n/g, "\\n")
+  .replace(/\t/g, "\\t")
+  .replace(/\${/g, "\\${")
+  .replace(/'/g, "\\'");
   return `'${escaped}'`;
 }

--- a/src/autorest.bicep/src/sample-generator.ts
+++ b/src/autorest.bicep/src/sample-generator.ts
@@ -1,0 +1,110 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { keys } from 'lodash';
+import { getFullyQualifiedType, ProviderDefinition, PutExample, ResourceDescriptor } from "./resources";
+
+export function getSampleMarkdown(definition: ProviderDefinition) {
+  let mdSamples = `
+# ${definition.namespace}
+`;
+
+  for (const resourceType of keys(definition.resourcesByType)) {
+    const descriptor = definition.resourcesByType[resourceType][0].descriptor;
+    const putExamples = definition.resourcesByType[resourceType].flatMap(x => x.putExamples ?? []);
+    if (putExamples.length === 0) {
+      continue;
+    }
+
+    mdSamples += `
+## ${resourceType}
+`;
+    
+    for (const example of putExamples) {
+      const bicepContent = generateBicepSample(definition, descriptor, example);
+      if (!bicepContent) {
+        continue;
+      }
+
+      mdSamples += `
+${example.description}
+\`\`\`bicep
+${bicepContent}
+\`\`\`
+`;
+    }
+  }
+
+  return mdSamples;
+}
+
+function generateBicepSample(provider: ProviderDefinition, descriptor: ResourceDescriptor, example: PutExample) {
+  if (typeof example.body !== 'object') {
+    return;
+  }
+  
+  let result = `resource exampleResource '${getFullyQualifiedType(descriptor)}@${provider.apiVersion}' = {\n`;
+  if (descriptor.typeSegments.length > 1) {
+    result += `  parent: parentResource \n`;
+  }
+  result += `  name: 'example'\n`;
+
+  for (const propName of keys(example.body)) {
+    result += `  ${propName}: ${getBicep(example.body[propName], 1)}\n`;
+  }
+
+  result += `}`;
+
+  return result;
+}
+
+function getIndent(indent: number) {
+  return '  '.repeat(indent);
+}
+
+function getBicep(value: any, indent: number) {
+  if (typeof value === 'string') {
+    return getBicepString(value);
+  }
+
+  if (typeof value === 'number') {
+    return value.toString();
+  }
+
+  if (typeof value === 'boolean') {
+    return value ? 'true' : 'false';
+  }
+
+  if (Array.isArray(value)) {
+    let result = `[`;
+    for (const item of value) {
+      result += `\n${getIndent(indent + 1)}${getBicep(item, indent + 1)}`;
+    }
+    result += `\n${getIndent(indent)}]`;
+
+    return result;
+  }
+
+  if (typeof value === 'object') {
+    let result = `{`;
+    for (const key of keys(value)) {
+      result += `\n${getIndent(indent + 1)}${key}: ${getBicep(value[key], indent + 1)}`;
+    }
+    result += `\n${getIndent(indent)}}`;
+
+    return result;
+  }
+
+  throw new Error(`Unsupported type: ${typeof value}`);
+}
+
+function getBicepString(value: string) {
+  const escaped = value
+  .replace("\\", "\\\\") // must do this first!
+  .replace("\r", "\\r")
+  .replace("\n", "\\n")
+  .replace("\t", "\\t")
+  .replace("${", "\\${")
+  .replace("'", "\\'");
+  return `'${escaped}'`;
+}

--- a/src/autorest.bicep/test/integration/generated/bicep/basic/test.rp1/2021-10-31/samples.md
+++ b/src/autorest.bicep/test/integration/generated/bicep/basic/test.rp1/2021-10-31/samples.md
@@ -1,0 +1,17 @@
+
+# Test.Rp1
+
+## test.rp1/testtype1
+
+Put a TestType1 Resource
+```bicep
+resource exampleResource 'Test.Rp1/testType1@2021-10-31' = {
+  name: 'example'
+  location: 'westus'
+  properties: {
+    basicString: 'I\'m a string!'
+    intWithDefaultValue: 2
+    stringEnum: 'Foo'
+  }
+}
+```

--- a/src/autorest.bicep/test/integration/generated/bicep/basic/test.rp1/2021-10-31/samples.md
+++ b/src/autorest.bicep/test/integration/generated/bicep/basic/test.rp1/2021-10-31/samples.md
@@ -1,4 +1,3 @@
-
 # Test.Rp1
 
 ## test.rp1/testtype1

--- a/src/autorest.bicep/test/integration/generated/bicep/firewalls/microsoft.network/2021-08-01/samples.md
+++ b/src/autorest.bicep/test/integration/generated/bicep/firewalls/microsoft.network/2021-08-01/samples.md
@@ -1,2 +1,0 @@
-
-# Microsoft.Network

--- a/src/autorest.bicep/test/integration/generated/bicep/firewalls/microsoft.network/2021-08-01/samples.md
+++ b/src/autorest.bicep/test/integration/generated/bicep/firewalls/microsoft.network/2021-08-01/samples.md
@@ -1,0 +1,2 @@
+
+# Microsoft.Network

--- a/src/autorest.bicep/test/integration/specs/basic/resource-manager/Test.Rp1/stable/2021-10-31/examples/putTestType1.json
+++ b/src/autorest.bicep/test/integration/specs/basic/resource-manager/Test.Rp1/stable/2021-10-31/examples/putTestType1.json
@@ -1,0 +1,31 @@
+{
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "sample-group",
+    "typeName": "sample-res",
+    "api-version": "2021-10-31",
+    "parameters": {
+      "location": "westus",
+      "properties": {
+        "basicString": "I'm a string!",
+        "stringEnum": "Foo",
+        "intWithDefaultValue": 2
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sample-group/providers/Test.Rp1/testType1/sample-res",
+        "name": "sample-res",
+        "type": "Test.Rp1/testType1",
+        "location": "westus",
+        "properties": {
+          "basicString": "I'm a string!",
+          "stringEnum": "Foo",
+          "intWithDefaultValue": 2
+        }
+      }
+    }
+  }
+}

--- a/src/autorest.bicep/test/integration/specs/basic/resource-manager/Test.Rp1/stable/2021-10-31/spec.json
+++ b/src/autorest.bicep/test/integration/specs/basic/resource-manager/Test.Rp1/stable/2021-10-31/spec.json
@@ -404,6 +404,11 @@
             "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
           }
         ],
+        "x-ms-examples": {
+          "Put a TestType1 Resource": {
+            "$ref": "./examples/putTestType1.json"
+          }
+        },
         "x-ms-long-running-operation": true
       }
     },


### PR DESCRIPTION
Automatically find examples with the `x-ms-example` annotation, and generate sample Bicep code from them.