### PR TITLE
Add Dependabot configuration for .NET SDK updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,3 +28,13 @@ updates:
     ignore:
       - dependency-name: "Moq"
       - dependency-name: "FluentAssertions"
+  - package-ecosystem: dotnet-sdk
+    directory: /
+    schedule:
+      interval: weekly
+      day: wednesday
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - version-update:semver-major
+          - version-update:semver-minor


### PR DESCRIPTION
This PR adds Dependabot configuration to automatically manage .NET SDK version updates in global.json.

This configuration will:
- Monitor the global.json file for .NET SDK version updates
- Create pull requests when new SDK versions are available
- Help keep the project secure with the latest SDK patches

For more information, see: https://devblogs.microsoft.com/dotnet/using-dependabot-to-manage-dotnet-sdk-updates/