### PR TITLE
Fix types workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,11 +82,11 @@ jobs:
         uses: github/codeql-action/init@v3
         with:
           languages: javascript
-  
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 22.x
 
       - name: Build bicep-types dependency
         run: |
@@ -131,7 +131,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 22.x
 
       - name: Build bicep-types dependency
         run: |

--- a/.github/workflows/update-types.yml
+++ b/.github/workflows/update-types.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 22.x
 
       - name: Clone azure-rest-api-specs
         uses: actions/checkout@v4

--- a/src/generator/src/cmd/generate.ts
+++ b/src/generator/src/cmd/generate.ts
@@ -5,6 +5,7 @@ import path from 'path';
 import { existsSync } from 'fs';
 import { mkdir, rm, writeFile, readFile } from 'fs/promises';
 import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers'
 import { TypeFile, buildIndex, writeIndexJson, writeIndexMarkdown, readTypesJson } from "bicep-types";
 import { GeneratorConfig, getConfig } from '../config';
 import * as markdown from '@ts-common/commonmark-to-markdown'
@@ -17,7 +18,7 @@ const extensionDir = path.resolve(`${rootDir}/src/autorest.bicep/`);
 const autorestBinary = os.platform() === 'win32' ? 'autorest.cmd' : 'autorest';
 const defaultOutDir = path.resolve(`${rootDir}/generated`);
 
-const argsConfig = yargs
+const argsConfig = yargs(hideBin(process.argv))
   .strict()
   .option('specs-dir', { type: 'string', demandOption: true, desc: 'Path to the specs dir' })
   .option('out-dir', { type: 'string', default: defaultOutDir, desc: 'Output path for generated files' })
@@ -71,7 +72,7 @@ executeSynchronous(async () => {
       bicepReadmePath: `${path.dirname(readmePath)}/readme.bicep.md`,
       config: getConfig(basePath),
       tmpOutputDir: `${tmpOutputPath}/${outputBasePath}`,
-      outputDir: `${outputBaseDir}/${outputBasePath}`,  
+      outputDir: `${outputBaseDir}/${outputBasePath}`,
     };
   });
 
@@ -125,7 +126,7 @@ ${err}
   if (!singlePath) {
     // log if there are any type dirs with no corresponding readme (e.g. if a swagger directory has been removed).
     const shouldRebuildTypeIndex = await clearStaleTypeFolders(defaultLogger, outputBaseDir, pathData.map(x => x.outputDir));
-    
+
     if (shouldRebuildTypeIndex) {
       await buildTypeIndex(defaultLogger, outputBaseDir);
     }
@@ -283,7 +284,7 @@ async function clearStaleTypeFolders(logger: ILogger, outputBaseDir: string, out
   for (const basePath of staleBasePaths) {
     await rm(`${outputBaseDir}/${basePath}`, { recursive: true, force: true, });
   }
-  
+
   return staleBasePaths.length > 0;
 }
 


### PR DESCRIPTION
The update-types workflow has been failing for the last few weeks due to bitrot. I updated the workflow to use the current node LTS version (22.x instead of 16.x) and update the generate command initialization to reflect recent updates to `yargs`.