### PR TITLE
fix: remove stale keyvault additionalFiles workaround that broke generation after specs restructure

### DIFF
--- a/src/generator/src/config.ts
+++ b/src/generator/src/config.ts
@@ -10,14 +10,6 @@ const defaultConfig: GeneratorConfig = {
 }
 
 const config: Record<string, GeneratorConfig> = {
-  'keyvault': {
-    additionalFiles: [
-      'Microsoft.KeyVault/stable/2016-10-01/secrets.json',
-      'Microsoft.KeyVault/stable/2018-02-14/secrets.json',
-      'Microsoft.KeyVault/preview/2018-02-14-preview/secrets.json',
-      'Microsoft.KeyVault/stable/2019-09-01/secrets.json',
-    ],
-  }
 }
 
 export function getConfig(basePath: string): GeneratorConfig {


### PR DESCRIPTION
## Problem

KeyVault API versions `2026-02-01` and `2026-03-01-preview` were missing from
the generated types in `generated/keyvault/`. The root cause was a broken file
path in `src/generator/src/config.ts`.

The `additionalFiles` config for `keyvault` contained paths relative to the
**old** readme location (`Microsoft.KeyVault/readme.md`):

```ts
additionalFiles: [
  'Microsoft.KeyVault/stable/2016-10-01/secrets.json',
  'Microsoft.KeyVault/stable/2018-02-14/secrets.json',
  'Microsoft.KeyVault/preview/2018-02-14-preview/secrets.json',
  'Microsoft.KeyVault/stable/2019-09-01/secrets.json',
]