### PR TITLE
Include all bicep actions into ResourceFunctions index

### DIFF
--- a/src/autorest.bicep/src/resources.ts
+++ b/src/autorest.bicep/src/resources.ts
@@ -492,10 +492,11 @@ export function getProviderDefinitions(codeModel: CodeModel, host: AutorestExten
 
   function getResponseSchema(operation?: Operation) {
     const responses = operation?.responses ?? [];
-    const successfulResponses = responses.filter(hasSuccessfulStatusCode);
-    const validResponses = successfulResponses.length > 0
-      ? successfulResponses
-      : responses.filter(r => hasStatusCode(r, "default"));
+    const validResponses = [
+      // order 2xx responses before default
+      ...responses.filter(hasSuccessfulStatusCode),
+      ...responses.filter(r => hasStatusCode(r, "default")),
+    ];
 
     if (!operation || validResponses.length === 0) {
       return;

--- a/src/autorest.bicep/src/resources.ts
+++ b/src/autorest.bicep/src/resources.ts
@@ -105,6 +105,11 @@ function hasStatusCode(response: Response, statusCode: string) {
   return (statusCodes as string[]).includes(statusCode);
 }
 
+function hasSuccessfulStatusCode(response: Response) {
+  const statusCodes = (response.protocol.http as HttpResponse)?.statusCodes;
+  return (statusCodes as string[] | undefined)?.some(statusCode => /^2\d\d$/.test(statusCode));
+}
+
 function getNormalizedMethodPath(path: string) {
   if (resourceGroupMethod.test(path)) {
     // resource groups are a special case - the swagger API is not defined as a provider API, but they are still deployable in a template as if it was.
@@ -487,11 +492,10 @@ export function getProviderDefinitions(codeModel: CodeModel, host: AutorestExten
 
   function getResponseSchema(operation?: Operation) {
     const responses = operation?.responses ?? [];
-    const validResponses = [
-      // order 200 responses before default
-      ...responses.filter(r => hasStatusCode(r, "200")),
-      ...responses.filter(r => hasStatusCode(r, "default")),
-    ];
+    const successfulResponses = responses.filter(hasSuccessfulStatusCode);
+    const validResponses = successfulResponses.length > 0
+      ? successfulResponses
+      : responses.filter(r => hasStatusCode(r, "default"));
 
     if (!operation || validResponses.length === 0) {
       return;

--- a/src/autorest.bicep/src/type-generator.ts
+++ b/src/autorest.bicep/src/type-generator.ts
@@ -245,6 +245,10 @@ export function generateTypes(host: AutorestExtensionHost, definition: ProviderD
         }
       }
 
+      if (!action.responseSchema) {
+        logWarning(`Resource action ${action.actionName} under path '${action.postRequest.path}' has no response schema. Returning 'any'.`);
+      }
+
       const response = action.responseSchema
         ? parseType(undefined, action.responseSchema)
         : factory.addAnyType();

--- a/src/autorest.bicep/src/type-generator.ts
+++ b/src/autorest.bicep/src/type-generator.ts
@@ -245,12 +245,9 @@ export function generateTypes(host: AutorestExtensionHost, definition: ProviderD
         }
       }
 
-      if (!action.responseSchema) {
-        logWarning(`Skipping resource action ${action.actionName} under path '${action.postRequest.path}': failed to find a response schema`);
-        continue;
-      }
-
-      const response = parseType(undefined, action.responseSchema);
+      const response = action.responseSchema
+        ? parseType(undefined, action.responseSchema)
+        : factory.addAnyType();
       if (response === undefined) {
         continue;
       }

--- a/src/autorest.bicep/test/integration/generated/bicep/basic/test.rp1/2021-10-31/types.json
+++ b/src/autorest.bicep/test/integration/generated/bicep/basic/test.rp1/2021-10-31/types.json
@@ -1687,5 +1687,14 @@
     "output": {
       "$ref": "#/111"
     }
+  },
+  {
+    "$type": "ResourceFunctionType",
+    "name": "restart",
+    "resourceType": "Test.Rp1/testType1",
+    "apiVersion": "2021-10-31",
+    "output": {
+      "$ref": "#/25"
+    }
   }
 ]

--- a/src/autorest.bicep/test/integration/generated/bicep/basic/test.rp1/2021-10-31/types.json
+++ b/src/autorest.bicep/test/integration/generated/bicep/basic/test.rp1/2021-10-31/types.json
@@ -1694,7 +1694,7 @@
     "resourceType": "Test.Rp1/testType1",
     "apiVersion": "2021-10-31",
     "output": {
-      "$ref": "#/25"
+      "$ref": "#/24"
     }
   }
 ]

--- a/src/autorest.bicep/test/integration/generated/bicep/basic/test.rp1/2021-10-31/types.md
+++ b/src/autorest.bicep/test/integration/generated/bicep/basic/test.rp1/2021-10-31/types.md
@@ -125,6 +125,11 @@
 * **Input**: [FoosRequest](#foosrequest)
 * **Output**: [FoosResponse](#foosresponse)
 
+## Function restart (Test.Rp1/testType1@2021-10-31)
+* **Resource**: Test.Rp1/testType1
+* **ApiVersion**: 2021-10-31
+* **Output**: any
+
 ## DiscriminatedUnionTestTypeProperties
 * **Discriminator**: type
 

--- a/src/autorest.bicep/test/integration/specs/basic/resource-manager/Test.Rp1/stable/2021-10-31/spec.json
+++ b/src/autorest.bicep/test/integration/specs/basic/resource-manager/Test.Rp1/stable/2021-10-31/spec.json
@@ -510,6 +510,46 @@
         ]
       }
     },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Test.Rp1/testType1/{typeName}/restart": {
+      "post": {
+        "summary": "Restart the testType1 resource",
+        "description": "Restart the testType1 resource",
+        "operationId": "TestType1_Restart",
+        "responses": {
+          "202": {
+            "description": "Accepted"
+          },
+          "204": {
+            "description": "No Content"
+          },
+          "default": {
+            "description": "Detailed error information.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "typeName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The testType1 resource name."
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "x-ms-long-running-operation": true
+      }
+    },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Test.Rp1/readOnlyTestType/{typeName}": {
       "get": {
         "summary": "Get a readOnlyTestType resource",


### PR DESCRIPTION
Updated ARM action discovery to accept all successful 2xx responses, including bodyless 202/204 operations, and emit schema-less actions as resource functions with an any output. Added integration coverage for a VM-style restart action to ensure it appears in the ResourceFunctions index.